### PR TITLE
Get copyrtighted articles. Make graphql work on old taxonomy without …

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -95,11 +95,10 @@ export async function fetchMovieMeta(
   const response = await fetch(
     `/article-api/v2/articles/?ids=${articleId}&language=${
       context.language
-    }&fallback=true`,
+    }&license=all&fallback=true`,
     context,
   );
   const json = await resolveJson(response);
-
   const article = json.results.find((item: { id: number }) => {
     return item.id.toString() === articleId;
   });
@@ -114,6 +113,8 @@ export async function fetchMovieMeta(
         ? { url: article.metaImage.url, alt: article.metaImage.alt }
         : undefined,
     };
+  } else {
+    console.log(articleId);
   }
   return null;
 }

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -113,8 +113,6 @@ export async function fetchMovieMeta(
         ? { url: article.metaImage.url, alt: article.metaImage.alt }
         : undefined,
     };
-  } else {
-    console.log(articleId);
   }
   return null;
 }

--- a/src/resolvers/subjectResolvers.ts
+++ b/src/resolvers/subjectResolvers.ts
@@ -19,12 +19,12 @@ export const Query = {
   ): Promise<GQLSubject> {
     const list = await fetchSubjects(context);
     return list
-      .filter(s => (s.metadata && s.metadata.visible) || true)
+      .filter(s => (s.metadata ? s.metadata.visible : true))
       .find(subject => subject.id === id);
   },
   async subjects(_: any, __: any, context: Context): Promise<GQLSubject[]> {
     const subjects = await fetchSubjects(context);
-    return subjects.filter(s => (s.metadata && s.metadata.visible) || true);
+    return subjects.filter(s => (s.metadata ? s.metadata.visible : true));
   },
   async filters(
     _: any,

--- a/src/resolvers/subjectResolvers.ts
+++ b/src/resolvers/subjectResolvers.ts
@@ -19,12 +19,12 @@ export const Query = {
   ): Promise<GQLSubject> {
     const list = await fetchSubjects(context);
     return list
-      .filter(s => s.metadata.visible === true)
+      .filter(s => s.metadata?.visible || true)
       .find(subject => subject.id === id);
   },
   async subjects(_: any, __: any, context: Context): Promise<GQLSubject[]> {
     const subjects = await fetchSubjects(context);
-    return subjects.filter(s => s.metadata.visible === true);
+    return subjects.filter(s => s.metadata?.visible || true);
   },
   async filters(
     _: any,

--- a/src/resolvers/subjectResolvers.ts
+++ b/src/resolvers/subjectResolvers.ts
@@ -19,12 +19,12 @@ export const Query = {
   ): Promise<GQLSubject> {
     const list = await fetchSubjects(context);
     return list
-      .filter(s => s.metadata?.visible || true)
+      .filter(s => (s.metadata && s.metadata.visible) || true)
       .find(subject => subject.id === id);
   },
   async subjects(_: any, __: any, context: Context): Promise<GQLSubject[]> {
     const subjects = await fetchSubjects(context);
-    return subjects.filter(s => s.metadata?.visible || true);
+    return subjects.filter(s => (s.metadata && s.metadata.visible) || true);
   },
   async filters(
     _: any,


### PR DESCRIPTION
…metadata

Fixes NDLANO/Issues#2078.

Artikler med lisens COPYRTIGHTED returneres ikkje som standard i article-api, men kun dersom vi spesifiserer enten license=COPYRIGHTED eller licence=all. Det var lagt inn en film i ndla-film med denne lisensen og det takla ikkje koden.

Fiksa også at graphql kan kjøres mot taksonomi uten visible for subjects.