### PR TITLE
Use first subject filter when no filterIds are provided

### DIFF
--- a/src/resolvers/subjectResolvers.ts
+++ b/src/resolvers/subjectResolvers.ts
@@ -44,7 +44,9 @@ export const resolvers = {
     ): Promise<GQLTopic[]> {
       const topics = await context.loaders.subjectTopicsLoader.load({
         subjectId: subject.id,
-        filterIds: args.filterIds,
+        filterIds:
+          args.filterIds ||
+          (await context.loaders.filterLoader.load(subject.id))[0].id,
       });
       if (args.all) {
         return filterMissingArticles(topics, context);


### PR DESCRIPTION
NDLANO/Issues#2235

Bruker det første filteret til et fag når filterIds ikke er gitt. Regner med at alle fag har filter?