### PR TITLE
Add subjectid to filter

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -282,6 +282,7 @@ export const typeDefs = gql`
     name: String!
     connectionId: String
     relevanceId: String
+    subjectId: String
   }
 
   type SubjectFilter {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -230,6 +230,7 @@ declare global {
     name: string;
     connectionId?: string;
     relevanceId?: string;
+    subjectId?: string;
   }
   
   export interface GQLLearningpath {
@@ -1428,6 +1429,7 @@ declare global {
     name?: FilterToNameResolver<TParent>;
     connectionId?: FilterToConnectionIdResolver<TParent>;
     relevanceId?: FilterToRelevanceIdResolver<TParent>;
+    subjectId?: FilterToSubjectIdResolver<TParent>;
   }
   
   export interface FilterToIdResolver<TParent = any, TResult = any> {
@@ -1443,6 +1445,10 @@ declare global {
   }
   
   export interface FilterToRelevanceIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FilterToSubjectIdResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
NDLANO/Issues#2235

Funksjonen som automatisk setter filter på en ressurs, kan fort bruke et filter fra subject som ikkje er satt på ressursen. Derfor må vi kunne sjekke at filteret som settes faktisk er på korrekt subject og må derfor returnere subjectId som felt på filter.