### PR TITLE
Add preliminary support for metadata on filters

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -48,7 +48,7 @@ export async function fetchFilters(
   context: Context,
 ): Promise<GQLSubjectFilter[]> {
   const response = await fetch(
-    `/taxonomy/v1/filters/?includeMetadata=true&language=${context.language}`,
+    `/taxonomy/v1/filters/?language=${context.language}`,
     context,
   );
   return resolveJson(response);
@@ -66,7 +66,7 @@ export async function fetchResourceTypes(
 
 export async function fetchSubjects(context: Context): Promise<GQLSubject[]> {
   const response = await fetch(
-    `/taxonomy/v1/subjects/?includeMetadata=true&language=${context.language}`,
+    `/taxonomy/v1/subjects/?language=${context.language}`,
     context,
   );
   return resolveJson(response);
@@ -79,7 +79,7 @@ export async function fetchSubjectTopics(
 ) {
   const filterParam = filterIds ? `&filter=${filterIds}` : '';
   const response = await fetch(
-    `/taxonomy/v1/subjects/${subjectId}/topics/?includeMetadata=true&recursive=true&language=${context.language}${filterParam}`,
+    `/taxonomy/v1/subjects/${subjectId}/topics/?recursive=true&language=${context.language}${filterParam}`,
     context,
   );
   return resolveJson(response);
@@ -87,7 +87,7 @@ export async function fetchSubjectTopics(
 
 export async function fetchTopics(context: Context): Promise<GQLTopic[]> {
   const response = await fetch(
-    `/taxonomy/v1/topics/?includeMetadata=true&language=${context.language}`,
+    `/taxonomy/v1/topics/?language=${context.language}`,
     context,
   );
   return resolveJson(response);
@@ -98,7 +98,7 @@ export async function fetchTopic(
   context: Context,
 ) {
   const response = await fetch(
-    `/taxonomy/v1/topics/${params.id}?includeMetadata=true&language=${context.language}`,
+    `/taxonomy/v1/topics/${params.id}?language=${context.language}`,
     context,
   );
   const topic: GQLTaxonomyEntity = await resolveJson(response);
@@ -129,7 +129,7 @@ export async function fetchTopicFilters(
   context: Context,
 ): Promise<GQLFilter[]> {
   const response = await fetch(
-    `/taxonomy/v1/topics/${topicId}/filters?includeMetadata=true`,
+    `/taxonomy/v1/topics/${topicId}/filters`,
     context,
   );
   return resolveJson(response);
@@ -145,7 +145,7 @@ export async function fetchTopicResources(
   const subjectParam = subjectId ? `&subject=${subjectId}` : '';
 
   const response = await fetch(
-    `/taxonomy/v1/topics/${topicId}/resources?includeMetadata=true&relevance=${relevance}&language=${context.language}${filterParam}${subjectParam}`,
+    `/taxonomy/v1/topics/${topicId}/resources?relevance=${relevance}&language=${context.language}${filterParam}${subjectParam}`,
     context,
   );
   const resources: GQLTaxonomyEntity[] = await resolveJson(response);

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -48,7 +48,7 @@ export async function fetchFilters(
   context: Context,
 ): Promise<GQLSubjectFilter[]> {
   const response = await fetch(
-    `/taxonomy/v1/filters/?language=${context.language}`,
+    `/taxonomy/v1/filters/?includeMetadata=true&language=${context.language}`,
     context,
   );
   return resolveJson(response);
@@ -129,7 +129,7 @@ export async function fetchTopicFilters(
   context: Context,
 ): Promise<GQLFilter[]> {
   const response = await fetch(
-    `/taxonomy/v1/topics/${topicId}/filters`,
+    `/taxonomy/v1/topics/${topicId}/filters?includeMetadata=true`,
     context,
   );
   return resolveJson(response);

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -57,7 +57,9 @@ export function filterLoader(
   return new DataLoader(async subjectIds => {
     const filterList = await fetchFilters(context);
     return subjectIds.map(subjectId =>
-      filterList.filter(filter => filter.subjectId === subjectId),
+      filterList
+        .filter(filter => filter.subjectId === subjectId)
+        .filter(filter => (filter.metadata ? filter.metadata.visible : true)),
     );
   });
 }

--- a/src/resolvers/__tests__/__snapshots__/subjectResolver-test.ts.snap
+++ b/src/resolvers/__tests__/__snapshots__/subjectResolver-test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Fetch subject filters should filter out invisible elements 1`] = `
+Array [
+  Object {
+    "id": "urn:filter:1",
+    "metadata": Object {
+      "grepCodes": Array [],
+      "visible": true,
+    },
+    "name": "Filter 1",
+  },
+]
+`;
+
 exports[`Fetch subject should filter out invisible elements 1`] = `
 Array [
   Object {

--- a/src/resolvers/__tests__/subjectResolver-test.ts
+++ b/src/resolvers/__tests__/subjectResolver-test.ts
@@ -12,7 +12,7 @@ import { Query } from '../subjectResolvers';
 test('Fetch subject should filter out invisible elements', async () => {
   nock('https://api.test.ndla.no')
     .persist()
-    .get('/taxonomy/v1/subjects/?includeMetadata=true&language=nb')
+    .get('/taxonomy/v1/subjects/?language=nb')
     .reply(200, [
       {
         id: 'urn:subject:3',
@@ -47,7 +47,7 @@ test('Fetch subject should filter out invisible elements', async () => {
 test('Fetch subject filters should filter out invisible elements', async () => {
   nock('https://api.test.ndla.no')
     .persist()
-    .get('/taxonomy/v1/filters/?includeMetadata=true&language=nb')
+    .get('/taxonomy/v1/filters/?language=nb')
     .reply(200, [
       {
         id: 'urn:filter:1',

--- a/src/resolvers/__tests__/subjectResolver-test.ts
+++ b/src/resolvers/__tests__/subjectResolver-test.ts
@@ -43,3 +43,34 @@ test('Fetch subject should filter out invisible elements', async () => {
 
   expect(subs).toMatchSnapshot();
 });
+
+test('Fetch subject filters should filter out invisible elements', async () => {
+  nock('https://api.test.ndla.no')
+    .persist()
+    .get('/taxonomy/v1/filters/?includeMetadata=true&language=nb')
+    .reply(200, [
+      {
+        id: 'urn:filter:1',
+        name: 'Filter 1',
+        metadata: {
+          grepCodes: [],
+          visible: true,
+        },
+      },
+      {
+        id: 'urn:filter:2',
+        name: 'Filter 2',
+        metadata: {
+          grepCodes: [],
+          visible: false,
+        },
+      },
+    ]);
+
+  const subs = await Query.filters(1, 1, {
+    language: 'nb',
+    shouldUseCache: false,
+  });
+
+  expect(subs).toMatchSnapshot();
+});

--- a/src/resolvers/subjectResolvers.ts
+++ b/src/resolvers/subjectResolvers.ts
@@ -31,7 +31,10 @@ export const Query = {
     __: any,
     context: Context,
   ): Promise<GQLSubjectFilter[]> {
-    return fetchFilters(context);
+    const filters = await fetchFilters(context);
+    return filters.filter(filter =>
+      filter.metadata ? filter.metadata.visible : true,
+    );
   },
 };
 

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -78,7 +78,10 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
       _: any,
       context: Context,
     ): Promise<GQLFilter[]> {
-      return fetchTopicFilters(topic.id, context);
+      const filters = await fetchTopicFilters(topic.id, context);
+      return filters.filter(filter =>
+        filter.metadata ? filter.metadata.visible : true,
+      );
     },
     async meta(
       topic: TopicResponse,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -283,6 +283,7 @@ export const typeDefs = gql`
     connectionId: String
     relevanceId: String
     subjectId: String
+    metadata: TaxonomyMetadata
   }
 
   type SubjectFilter {
@@ -291,6 +292,7 @@ export const typeDefs = gql`
     subjectId: String!
     contentUri: String
     subjectpage: SubjectPage
+    metadata: TaxonomyMetadata
   }
 
   type Category {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -231,6 +231,7 @@ declare global {
     connectionId?: string;
     relevanceId?: string;
     subjectId?: string;
+    metadata?: GQLTaxonomyMetadata;
   }
   
   export interface GQLLearningpath {
@@ -335,6 +336,7 @@ declare global {
     subjectId: string;
     contentUri?: string;
     subjectpage?: GQLSubjectPage;
+    metadata?: GQLTaxonomyMetadata;
   }
   
   export interface GQLSubjectPage {
@@ -1444,6 +1446,7 @@ declare global {
     connectionId?: FilterToConnectionIdResolver<TParent>;
     relevanceId?: FilterToRelevanceIdResolver<TParent>;
     subjectId?: FilterToSubjectIdResolver<TParent>;
+    metadata?: FilterToMetadataResolver<TParent>;
   }
   
   export interface FilterToIdResolver<TParent = any, TResult = any> {
@@ -1463,6 +1466,10 @@ declare global {
   }
   
   export interface FilterToSubjectIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FilterToMetadataResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1866,6 +1873,7 @@ declare global {
     subjectId?: SubjectFilterToSubjectIdResolver<TParent>;
     contentUri?: SubjectFilterToContentUriResolver<TParent>;
     subjectpage?: SubjectFilterToSubjectpageResolver<TParent>;
+    metadata?: SubjectFilterToMetadataResolver<TParent>;
   }
   
   export interface SubjectFilterToIdResolver<TParent = any, TResult = any> {
@@ -1885,6 +1893,10 @@ declare global {
   }
   
   export interface SubjectFilterToSubjectpageResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface SubjectFilterToMetadataResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
NDLANO/issues#2243

Taksonomi har ikkje endå støtte for metadata på filter, men dette kjem i løpet av neste veke.

På taksonomiversjon uten metadata på filter skippes filtreringa og alle filter returneres.