### PR TITLE
#2375: Adds resolver for fetching all topics in each path for topics

### DIFF
--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -148,9 +148,9 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
             .split('/')
             .filter(pathElement => pathElement.includes('topic:'));
           return Promise.all(
-            topicsToFetch.map(async id => {
-              return fetchTopic({ id: `urn:${id}` }, context);
-            }),
+            topicsToFetch.map(async id =>
+              fetchTopic({ id: `urn:${id}` }, context),
+            ),
           );
         }),
       );

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -26,6 +26,7 @@ interface TopicResponse {
   name: string;
   contentUri?: string;
   path?: string;
+  paths?: string[];
 }
 
 export const Query = {
@@ -135,6 +136,24 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
         context,
       );
       return filterMissingArticles(subtopics, context);
+    },
+    async pathTopics(
+      topic: TopicResponse,
+      args: TopicToSubtopicsArgs,
+      context: Context,
+    ): Promise<GQLTopic[][]> {
+      return Promise.all(
+        topic.paths?.map(async path => {
+          const topicsToFetch = path
+            .split('/')
+            .filter(pathElement => pathElement.includes('topic:'));
+          return Promise.all(
+            topicsToFetch.map(async id => {
+              return fetchTopic({ id: `urn:${id}` }, context);
+            }),
+          );
+        }),
+      );
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -142,6 +142,7 @@ export const typeDefs = gql`
     isPrimary: Boolean
     parent: String
     subtopics(filterIds: String): [Topic]
+    pathTopics: [[Topic]]
     coreResources(filterIds: String, subjectId: String): [Resource]
     supplementaryResources(filterIds: String, subjectId: String): [Resource]
   }

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -331,6 +331,7 @@ declare global {
     isPrimary?: boolean;
     parent?: string;
     subtopics?: Array<GQLTopic | null>;
+    pathTopics?: Array<Array<GQLTopic | null> | null>;
     coreResources?: Array<GQLResource | null>;
     supplementaryResources?: Array<GQLResource | null>;
   }
@@ -1835,6 +1836,7 @@ declare global {
     isPrimary?: TopicToIsPrimaryResolver<TParent>;
     parent?: TopicToParentResolver<TParent>;
     subtopics?: TopicToSubtopicsResolver<TParent>;
+    pathTopics?: TopicToPathTopicsResolver<TParent>;
     coreResources?: TopicToCoreResourcesResolver<TParent>;
     supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
   }
@@ -1892,6 +1894,10 @@ declare global {
   }
   export interface TopicToSubtopicsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: TopicToSubtopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathTopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface TopicToCoreResourcesArgs {


### PR DESCRIPTION
Relates to NDLANO/Issues#2375

Ganske spesifikk sak for å hente ut informasjon om topics i path'ene til andre topics.
Som vi snakket om på slack så er dette for å slippe å gjøre 2 kall til graphql.

Kan testes med en query som ligner på denne:
```
query topicQuery($topicId: String!) {
  topic(id: $topicId) {
    id
    path
    pathTopics {
      id
      name
    }
  }
}
```
Med disse variablene (i staging):
`{"topicId": "urn:topic:5995487e-cf18-46ea-a6e9-7a4d5260cb1d"}`

Gir dette resultatet:
```
{
  "data": {
    "topic": {
      "id": "urn:topic:5995487e-cf18-46ea-a6e9-7a4d5260cb1d",
      "path": "/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/topic:de913bcd-93ee-4143-9cc2-1d4e2c80977f/topic:bbe2496c-615d-4466-99ce-c999e8e9aca1/topic:5995487e-cf18-46ea-a6e9-7a4d5260cb1d",
      "pathTopics": [
        [
          {
            "id": "urn:topic:de913bcd-93ee-4143-9cc2-1d4e2c80977f",
            "name": "Folkehelse og livsmestring"
          },
          {
            "id": "urn:topic:bbe2496c-615d-4466-99ce-c999e8e9aca1",
            "name": "Fysisk og psykisk helse"
          },
          {
            "id": "urn:topic:5995487e-cf18-46ea-a6e9-7a4d5260cb1d",
            "name": "Kredittfella"
          }
        ]
      ]
    }
  }
}
```

Om det er for spesifikt til å ha i graphql-api'et så kan vi løse problemet med 2 kall som depender på hverandre i ndla-frontend som Bjørnar hadde et eksempel på:
```
const [getOtherData, { data: otherData }] = useLazyQuery(otherQuery);
const { data } = useQuery(topicQuery, {
	onCompleted: data => getOtherData({
		variables: {
			ids: data.ids
		}
	})

```

Hva som er best aner jeg ikke ¯\_(ツ)_/¯
All feedback tas i mot med takk :smile: 