### PR TITLE
Ta høgde for at gamle forklaringer ikkje alltid har lisens.

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -221,7 +221,7 @@ export const typeDefs = gql`
   type ConceptLicense {
     title: String!
     src: String
-    copyright: Copyright!
+    copyright: Copyright
   }
 
   type ArticleMetaData {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -203,7 +203,7 @@ declare global {
   export interface GQLConceptLicense {
     title: string;
     src?: string;
-    copyright: GQLCopyright;
+    copyright?: GQLCopyright;
   }
   
   export interface GQLCompetenceGoal {


### PR DESCRIPTION
Læringssteg som har artikler med forklaring uten lisens har slutta å fungere etter at vi la iframe-visninger bak graphql. Det er fordi copyright er satt som påkrevd for forklaring, men det er mange forklaringer som ikkje har disse dataene.

Må deployes for å kunne teste, men [denne artikkelen](https://test.ndla.no/article/22687) feiler i dag men fungerer med denne endringa.