### PR TITLE
Jumping through hoops to find correct filters

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -8,8 +8,12 @@
 
 import { fetch, resolveJson } from '../utils/apiHelpers';
 
+interface Topic {
+  id: string;
+  path: string;
+}
 interface FetchTopicResourcesParams {
-  topicId: string;
+  topic: Topic;
   relevance: string;
   filters?: string;
   subjectId?: string;
@@ -139,13 +143,12 @@ export async function fetchTopicResources(
   params: FetchTopicResourcesParams,
   context: Context,
 ): Promise<GQLResource[]> {
-  const { filters, subjectId, relevance, topicId } = params;
-
+  const { filters, subjectId, relevance, topic } = params;
   const filterParam = filters && filters.length > 0 ? `&filter=${filters}` : '';
   const subjectParam = subjectId ? `&subject=${subjectId}` : '';
 
   const response = await fetch(
-    `/taxonomy/v1/topics/${topicId}/resources?language=${context.language}${filterParam}${subjectParam}`,
+    `/taxonomy/v1/topics/${topic.id}/resources?language=${context.language}${filterParam}${subjectParam}`,
     context,
   );
   const resources: GQLTaxonomyEntity[] = await resolveJson(response);
@@ -157,10 +160,14 @@ export async function fetchTopicResources(
     }
   });
 
+  // Only check filters from subject containing topic. Should be fixed in tax.
+  const topicSubject = `urn:${topic.path
+    .split('/')
+    .find(token => token.includes('subject'))}`;
   const suplResources = resources.filter(resource =>
-    resource.filters?.find(
-      filter => filter.relevanceId === 'urn:relevance:supplementary',
-    ),
+    resource.filters
+      ?.filter(filter => filter.subjectId === topicSubject)
+      ?.find(filter => filter.relevanceId === 'urn:relevance:supplementary'),
   );
   const coreResources = resources.filter(
     resource => !suplResources.includes(resource),

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -164,11 +164,14 @@ export async function fetchTopicResources(
   const topicSubject = `urn:${topic.path
     .split('/')
     .find(token => token.includes('subject'))}`;
-  const suplResources = resources.filter(resource =>
-    resource.filters
-      ?.filter(filter => filter.subjectId === topicSubject)
-      ?.find(filter => filter.relevanceId === 'urn:relevance:supplementary'),
-  );
+  const suplResources = resources.filter(resource => {
+    const subjectFilters = resource.filters?.filter(
+      filter => filter.subjectId === topicSubject,
+    );
+    return subjectFilters?.find(
+      filter => filter.relevanceId === 'urn:relevance:supplementary',
+    );
+  });
   const coreResources = resources.filter(
     resource => !suplResources.includes(resource),
   );

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -25,7 +25,7 @@ interface TopicResponse {
   id: string;
   name: string;
   contentUri?: string;
-  path?: string;
+  path: string;
   paths?: string[];
 }
 
@@ -101,7 +101,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     ): Promise<GQLResource[]> {
       const topicResources = await fetchTopicResources(
         {
-          topicId: topic.id,
+          topic,
           subjectId: args.subjectId,
           relevance: 'urn:relevance:core',
           filters: args.filterIds,
@@ -117,7 +117,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     ): Promise<GQLResource[]> {
       const topicResources = await fetchTopicResources(
         {
-          topicId: topic.id,
+          topic,
           subjectId: args.subjectId,
           relevance: 'urn:relevance:supplementary',
           filters: args.filterIds,


### PR DESCRIPTION
I og med at vi ikkje kan sende relevance til taksonomi, må vi sjekke filter tilhørende faget emnet hører til for å sjå om en ressurs er kjernestoff eller tilleggstoff. Og fordi topic ikkje direkte har id til subject må path brukes for å finne korrekt subject. Dette er ok fordi en topic kun kan finnes i ett subject.
