### PR TITLE
2417 tt grepcode connections

### DIFF
--- a/src/api/curriculumApi.ts
+++ b/src/api/curriculumApi.ts
@@ -90,6 +90,13 @@ interface CoreElement extends GrepElement {
   'tilhoerer-laereplan': Reference;
 }
 
+interface CrossSubjectTopic {
+  id: string;
+  kode: string;
+  tittel: Text[];
+  'lenke-til-beskrivelse': string;
+}
+
 function mapReference(reference: Reference) {
   return {
     id: reference.kode,
@@ -277,6 +284,30 @@ async function fetchCrossSubjectTopic(
     language,
     '/grep/kl06/v201906/tverrfaglige-temaer-lk20/',
     context,
+  );
+}
+
+export async function fetchCrossSubjectTopicsByCode(
+  codes: string[],
+  language: string,
+  context: Context,
+): Promise<GQLReference[]> {
+  return Promise.all(
+    codes.map(async code => {
+      const response = await fetch(
+        `/grep/kl06/v201906/tverrfaglige-temaer-lk20/${code}`,
+        context,
+      );
+      const json: CrossSubjectTopic = await resolveJson(response);
+
+      const title = filterTextsForLanguage(json.tittel, language);
+
+      return {
+        code: json.kode,
+        id: json.kode,
+        title,
+      };
+    }),
   );
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,7 @@ export {
   fetchCoreElement,
   fetchCoreElements,
   fetchCoreElementReferences,
+  fetchCrossSubjectTopicsByCode,
   fetchCrossSubjectTopics,
   fetchLK06Curriculum,
   fetchLK20Curriculum,

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -53,7 +53,6 @@ export const resolvers = {
     async crossSubjectTopics(
       article: GQLArticle,
       args: { subjectId: string; filterIds: string },
-      _: any,
       context: Context,
     ): Promise<GQLTopic[]> {
       const crossSubjectCodes = article.grepCodes.filter(code =>

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -6,7 +6,13 @@
  *
  */
 
-import { fetchArticle, fetchCompetenceGoals, fetchCoreElements } from '../api';
+import {
+  fetchArticle,
+  fetchCompetenceGoals,
+  fetchCoreElements,
+  fetchCrossSubjectTopicsByCode,
+  fetchSubjectTopics,
+} from '../api';
 
 export const Query = {
   async article(
@@ -43,6 +49,35 @@ export const resolvers = {
         article.supportedLanguages.find(lang => lang === context.language) ||
         article.supportedLanguages[0];
       return fetchCoreElements(article.grepCodes, language, context);
+    },
+    async crossSubjectTopics(
+      article: GQLArticle,
+      args: { subjectId: string; filterIds: string },
+      _: any,
+      context: Context,
+    ): Promise<GQLTopic[]> {
+      const crossSubjectCodes = article.grepCodes.filter(code =>
+        code.startsWith('TT'),
+      );
+      const language =
+        article.supportedLanguages.find(lang => lang === context.language) ||
+        article.supportedLanguages[0];
+      const crossSubjectTopicInfo = await fetchCrossSubjectTopicsByCode(
+        crossSubjectCodes,
+        language,
+        context,
+      );
+      const topics = await fetchSubjectTopics(
+        args.subjectId,
+        args.filterIds,
+        context,
+      );
+      return crossSubjectTopicInfo.map(
+        compGoal =>
+          topics.find(
+            (topic: { name: string }) => topic.name === compGoal.title,
+          ) || { name: compGoal.title, id: '' },
+      );
     },
   },
 };

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -54,7 +54,7 @@ export const resolvers = {
       article: GQLArticle,
       args: { subjectId: string; filterIds: string },
       context: Context,
-    ): Promise<GQLTopic[]> {
+    ): Promise<GQLCrossSubjectElement[]> {
       const crossSubjectCodes = article.grepCodes.filter(code =>
         code.startsWith('TT'),
       );
@@ -72,10 +72,10 @@ export const resolvers = {
         context,
       );
       return crossSubjectTopicInfo.map(
-        compGoal =>
-          topics.find(
-            (topic: { name: string }) => topic.name === compGoal.title,
-          ) || { name: compGoal.title, id: '' },
+        crossSubjectTopic => ({
+          ...crossSubjectTopic,
+          path: topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title)?.path,
+        })
       );
     },
   },

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -71,12 +71,12 @@ export const resolvers = {
         args.filterIds,
         context,
       );
-      return crossSubjectTopicInfo.map(
-        crossSubjectTopic => ({
-          ...crossSubjectTopic,
-          path: topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title)?.path,
-        })
-      );
+      return crossSubjectTopicInfo.map(crossSubjectTopic => ({
+        ...crossSubjectTopic,
+        path: topics.find(
+          (topic: { name: string }) => topic.name === crossSubjectTopic.title,
+        )?.path,
+      }));
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -259,7 +259,10 @@ export const typeDefs = gql`
     grepCodes: [String]
     competenceGoals: [CompetenceGoal]
     coreElements: [CoreElement]
-    crossSubjectTopics(subjectId: String, filterIds: String): [CrossSubjectElement]
+    crossSubjectTopics(
+      subjectId: String
+      filterIds: String
+    ): [CrossSubjectElement]
     oembed: String
   }
 
@@ -288,7 +291,7 @@ export const typeDefs = gql`
     curriculumCode: String
     curriculum: Reference
   }
-  
+
   type CrossSubjectElement {
     title: String!
     code: String

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -259,6 +259,7 @@ export const typeDefs = gql`
     grepCodes: [String]
     competenceGoals: [CompetenceGoal]
     coreElements: [CoreElement]
+    crossSubjectTopics(subjectId: String, filterIds: String): [Topic]
     oembed: String
   }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -259,7 +259,7 @@ export const typeDefs = gql`
     grepCodes: [String]
     competenceGoals: [CompetenceGoal]
     coreElements: [CoreElement]
-    crossSubjectTopics(subjectId: String, filterIds: String): [Topic]
+    crossSubjectTopics(subjectId: String, filterIds: String): [CrossSubjectElement]
     oembed: String
   }
 
@@ -287,6 +287,12 @@ export const typeDefs = gql`
     language: String
     curriculumCode: String
     curriculum: Reference
+  }
+  
+  type CrossSubjectElement {
+    title: String!
+    code: String
+    path: String
   }
 
   type Element {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -117,7 +117,7 @@ declare global {
     grepCodes?: Array<string | null>;
     competenceGoals?: Array<GQLCompetenceGoal | null>;
     coreElements?: Array<GQLCoreElement | null>;
-    crossSubjectTopics?: Array<GQLTopic | null>;
+    crossSubjectTopics?: Array<GQLCrossSubjectElement | null>;
     oembed?: string;
   }
   
@@ -244,22 +244,10 @@ declare global {
     curriculum?: GQLReference;
   }
   
-  export interface GQLTopic extends GQLTaxonomyEntity {
-    id: string;
-    name: string;
-    contentUri?: string;
-    meta?: GQLMeta;
-    metadata?: GQLTaxonomyMetadata;
-    article?: GQLArticle;
-    filters?: Array<GQLFilter | null>;
+  export interface GQLCrossSubjectElement {
+    title: string;
+    code?: string;
     path?: string;
-    paths?: Array<string | null>;
-    isPrimary?: boolean;
-    parent?: string;
-    subtopics?: Array<GQLTopic | null>;
-    pathTopics?: Array<Array<GQLTopic | null> | null>;
-    coreResources?: Array<GQLResource | null>;
-    supplementaryResources?: Array<GQLResource | null>;
   }
   
   export interface GQLFilter {
@@ -336,6 +324,24 @@ declare global {
     id: string;
     name: string;
     resources?: Array<GQLResource | null>;
+  }
+  
+  export interface GQLTopic extends GQLTaxonomyEntity {
+    id: string;
+    name: string;
+    contentUri?: string;
+    meta?: GQLMeta;
+    metadata?: GQLTaxonomyMetadata;
+    article?: GQLArticle;
+    filters?: Array<GQLFilter | null>;
+    path?: string;
+    paths?: Array<string | null>;
+    isPrimary?: boolean;
+    parent?: string;
+    subtopics?: Array<GQLTopic | null>;
+    pathTopics?: Array<Array<GQLTopic | null> | null>;
+    coreResources?: Array<GQLResource | null>;
+    supplementaryResources?: Array<GQLResource | null>;
   }
   
   export interface GQLSubject {
@@ -640,7 +646,7 @@ declare global {
     Reference?: GQLReferenceTypeResolver;
     Element?: GQLElementTypeResolver;
     CoreElement?: GQLCoreElementTypeResolver;
-    Topic?: GQLTopicTypeResolver;
+    CrossSubjectElement?: GQLCrossSubjectElementTypeResolver;
     Filter?: GQLFilterTypeResolver;
     Learningpath?: GQLLearningpathTypeResolver;
     LearningpathCopyright?: GQLLearningpathCopyrightTypeResolver;
@@ -649,6 +655,7 @@ declare global {
     LearningpathStepOembed?: GQLLearningpathStepOembedTypeResolver;
     LearningpathCoverphoto?: GQLLearningpathCoverphotoTypeResolver;
     ResourceType?: GQLResourceTypeTypeResolver;
+    Topic?: GQLTopicTypeResolver;
     Subject?: GQLSubjectTypeResolver;
     SubjectFilter?: GQLSubjectFilterTypeResolver;
     SubjectPage?: GQLSubjectPageTypeResolver;
@@ -1568,97 +1575,22 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLTopicTypeResolver<TParent = any> {
-    id?: TopicToIdResolver<TParent>;
-    name?: TopicToNameResolver<TParent>;
-    contentUri?: TopicToContentUriResolver<TParent>;
-    meta?: TopicToMetaResolver<TParent>;
-    metadata?: TopicToMetadataResolver<TParent>;
-    article?: TopicToArticleResolver<TParent>;
-    filters?: TopicToFiltersResolver<TParent>;
-    path?: TopicToPathResolver<TParent>;
-    paths?: TopicToPathsResolver<TParent>;
-    isPrimary?: TopicToIsPrimaryResolver<TParent>;
-    parent?: TopicToParentResolver<TParent>;
-    subtopics?: TopicToSubtopicsResolver<TParent>;
-    pathTopics?: TopicToPathTopicsResolver<TParent>;
-    coreResources?: TopicToCoreResourcesResolver<TParent>;
-    supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
+  export interface GQLCrossSubjectElementTypeResolver<TParent = any> {
+    title?: CrossSubjectElementToTitleResolver<TParent>;
+    code?: CrossSubjectElementToCodeResolver<TParent>;
+    path?: CrossSubjectElementToPathResolver<TParent>;
   }
   
-  export interface TopicToIdResolver<TParent = any, TResult = any> {
+  export interface CrossSubjectElementToTitleResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface TopicToNameResolver<TParent = any, TResult = any> {
+  export interface CrossSubjectElementToCodeResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface TopicToContentUriResolver<TParent = any, TResult = any> {
+  export interface CrossSubjectElementToPathResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToMetaResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToMetadataResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToArticleArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToArticleResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToFiltersResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToIsPrimaryResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToParentResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToSubtopicsArgs {
-    filterIds?: string;
-  }
-  export interface TopicToSubtopicsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToSubtopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathTopicsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToCoreResourcesArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToCoreResourcesResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToCoreResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToSupplementaryResourcesArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToSupplementaryResourcesResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToSupplementaryResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface GQLFilterTypeResolver<TParent = any> {
@@ -1946,6 +1878,99 @@ declare global {
   }
   export interface ResourceTypeToResourcesResolver<TParent = any, TResult = any> {
     (parent: TParent, args: ResourceTypeToResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLTopicTypeResolver<TParent = any> {
+    id?: TopicToIdResolver<TParent>;
+    name?: TopicToNameResolver<TParent>;
+    contentUri?: TopicToContentUriResolver<TParent>;
+    meta?: TopicToMetaResolver<TParent>;
+    metadata?: TopicToMetadataResolver<TParent>;
+    article?: TopicToArticleResolver<TParent>;
+    filters?: TopicToFiltersResolver<TParent>;
+    path?: TopicToPathResolver<TParent>;
+    paths?: TopicToPathsResolver<TParent>;
+    isPrimary?: TopicToIsPrimaryResolver<TParent>;
+    parent?: TopicToParentResolver<TParent>;
+    subtopics?: TopicToSubtopicsResolver<TParent>;
+    pathTopics?: TopicToPathTopicsResolver<TParent>;
+    coreResources?: TopicToCoreResourcesResolver<TParent>;
+    supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
+  }
+  
+  export interface TopicToIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToNameResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToContentUriResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToMetaResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToMetadataResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToArticleArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToArticleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToFiltersResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToIsPrimaryResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToParentResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToSubtopicsArgs {
+    filterIds?: string;
+  }
+  export interface TopicToSubtopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToSubtopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathTopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToCoreResourcesArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToCoreResourcesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToCoreResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToSupplementaryResourcesArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToSupplementaryResourcesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToSupplementaryResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface GQLSubjectTypeResolver<TParent = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -117,6 +117,7 @@ declare global {
     grepCodes?: Array<string | null>;
     competenceGoals?: Array<GQLCompetenceGoal | null>;
     coreElements?: Array<GQLCoreElement | null>;
+    crossSubjectTopics?: Array<GQLTopic | null>;
     oembed?: string;
   }
   
@@ -243,6 +244,24 @@ declare global {
     curriculum?: GQLReference;
   }
   
+  export interface GQLTopic extends GQLTaxonomyEntity {
+    id: string;
+    name: string;
+    contentUri?: string;
+    meta?: GQLMeta;
+    metadata?: GQLTaxonomyMetadata;
+    article?: GQLArticle;
+    filters?: Array<GQLFilter | null>;
+    path?: string;
+    paths?: Array<string | null>;
+    isPrimary?: boolean;
+    parent?: string;
+    subtopics?: Array<GQLTopic | null>;
+    pathTopics?: Array<Array<GQLTopic | null> | null>;
+    coreResources?: Array<GQLResource | null>;
+    supplementaryResources?: Array<GQLResource | null>;
+  }
+  
   export interface GQLFilter {
     id: string;
     name: string;
@@ -317,24 +336,6 @@ declare global {
     id: string;
     name: string;
     resources?: Array<GQLResource | null>;
-  }
-  
-  export interface GQLTopic extends GQLTaxonomyEntity {
-    id: string;
-    name: string;
-    contentUri?: string;
-    meta?: GQLMeta;
-    metadata?: GQLTaxonomyMetadata;
-    article?: GQLArticle;
-    filters?: Array<GQLFilter | null>;
-    path?: string;
-    paths?: Array<string | null>;
-    isPrimary?: boolean;
-    parent?: string;
-    subtopics?: Array<GQLTopic | null>;
-    pathTopics?: Array<Array<GQLTopic | null> | null>;
-    coreResources?: Array<GQLResource | null>;
-    supplementaryResources?: Array<GQLResource | null>;
   }
   
   export interface GQLSubject {
@@ -639,6 +640,7 @@ declare global {
     Reference?: GQLReferenceTypeResolver;
     Element?: GQLElementTypeResolver;
     CoreElement?: GQLCoreElementTypeResolver;
+    Topic?: GQLTopicTypeResolver;
     Filter?: GQLFilterTypeResolver;
     Learningpath?: GQLLearningpathTypeResolver;
     LearningpathCopyright?: GQLLearningpathCopyrightTypeResolver;
@@ -647,7 +649,6 @@ declare global {
     LearningpathStepOembed?: GQLLearningpathStepOembedTypeResolver;
     LearningpathCoverphoto?: GQLLearningpathCoverphotoTypeResolver;
     ResourceType?: GQLResourceTypeTypeResolver;
-    Topic?: GQLTopicTypeResolver;
     Subject?: GQLSubjectTypeResolver;
     SubjectFilter?: GQLSubjectFilterTypeResolver;
     SubjectPage?: GQLSubjectPageTypeResolver;
@@ -1044,6 +1045,7 @@ declare global {
     grepCodes?: ArticleToGrepCodesResolver<TParent>;
     competenceGoals?: ArticleToCompetenceGoalsResolver<TParent>;
     coreElements?: ArticleToCoreElementsResolver<TParent>;
+    crossSubjectTopics?: ArticleToCrossSubjectTopicsResolver<TParent>;
     oembed?: ArticleToOembedResolver<TParent>;
   }
   
@@ -1129,6 +1131,14 @@ declare global {
   
   export interface ArticleToCoreElementsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleToCrossSubjectTopicsArgs {
+    subjectId?: string;
+    filterIds?: string;
+  }
+  export interface ArticleToCrossSubjectTopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: ArticleToCrossSubjectTopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface ArticleToOembedResolver<TParent = any, TResult = any> {
@@ -1558,6 +1568,99 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface GQLTopicTypeResolver<TParent = any> {
+    id?: TopicToIdResolver<TParent>;
+    name?: TopicToNameResolver<TParent>;
+    contentUri?: TopicToContentUriResolver<TParent>;
+    meta?: TopicToMetaResolver<TParent>;
+    metadata?: TopicToMetadataResolver<TParent>;
+    article?: TopicToArticleResolver<TParent>;
+    filters?: TopicToFiltersResolver<TParent>;
+    path?: TopicToPathResolver<TParent>;
+    paths?: TopicToPathsResolver<TParent>;
+    isPrimary?: TopicToIsPrimaryResolver<TParent>;
+    parent?: TopicToParentResolver<TParent>;
+    subtopics?: TopicToSubtopicsResolver<TParent>;
+    pathTopics?: TopicToPathTopicsResolver<TParent>;
+    coreResources?: TopicToCoreResourcesResolver<TParent>;
+    supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
+  }
+  
+  export interface TopicToIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToNameResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToContentUriResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToMetaResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToMetadataResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToArticleArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToArticleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToFiltersResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToIsPrimaryResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToParentResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToSubtopicsArgs {
+    filterIds?: string;
+  }
+  export interface TopicToSubtopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToSubtopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToPathTopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToCoreResourcesArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToCoreResourcesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToCoreResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToSupplementaryResourcesArgs {
+    filterIds?: string;
+    subjectId?: string;
+  }
+  export interface TopicToSupplementaryResourcesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: TopicToSupplementaryResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLFilterTypeResolver<TParent = any> {
     id?: FilterToIdResolver<TParent>;
     name?: FilterToNameResolver<TParent>;
@@ -1843,99 +1946,6 @@ declare global {
   }
   export interface ResourceTypeToResourcesResolver<TParent = any, TResult = any> {
     (parent: TParent, args: ResourceTypeToResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface GQLTopicTypeResolver<TParent = any> {
-    id?: TopicToIdResolver<TParent>;
-    name?: TopicToNameResolver<TParent>;
-    contentUri?: TopicToContentUriResolver<TParent>;
-    meta?: TopicToMetaResolver<TParent>;
-    metadata?: TopicToMetadataResolver<TParent>;
-    article?: TopicToArticleResolver<TParent>;
-    filters?: TopicToFiltersResolver<TParent>;
-    path?: TopicToPathResolver<TParent>;
-    paths?: TopicToPathsResolver<TParent>;
-    isPrimary?: TopicToIsPrimaryResolver<TParent>;
-    parent?: TopicToParentResolver<TParent>;
-    subtopics?: TopicToSubtopicsResolver<TParent>;
-    pathTopics?: TopicToPathTopicsResolver<TParent>;
-    coreResources?: TopicToCoreResourcesResolver<TParent>;
-    supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
-  }
-  
-  export interface TopicToIdResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToNameResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToContentUriResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToMetaResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToMetadataResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToArticleArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToArticleResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToFiltersResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToIsPrimaryResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToParentResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToSubtopicsArgs {
-    filterIds?: string;
-  }
-  export interface TopicToSubtopicsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToSubtopicsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToPathTopicsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToCoreResourcesArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToCoreResourcesResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToCoreResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface TopicToSupplementaryResourcesArgs {
-    filterIds?: string;
-    subjectId?: string;
-  }
-  export interface TopicToSupplementaryResourcesResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: TopicToSupplementaryResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface GQLSubjectTypeResolver<TParent = any> {


### PR DESCRIPTION
For NDLANO/ndla-frontend#629 og NDLANO/Issues#2417

Lagt til tverrfaglige temaer som et felt på `Article`, og basert dem på de tverrfaglige temaene som er linket til artikkelen med grepCodes.

Mulig playground test. Skal gi tre tverrfaglige temaer, hvor det ene ikke har path og id.
```
{
  topic(id: "urn:topic:16146345-8cc6-4729-8812-34f2b3593a76", subjectId: "urn:subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7") {
    id
    name
    path
    article(subjectId: "urn:subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7") {
      id
      title
      crossSubjectTopics(subjectId: "urn:subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7") {
        id
        name
        path
      }
    }
  }
}
```