### PR TITLE
2442 relaterte forklaringer til artikler

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -40,27 +40,23 @@ export async function fetchConcepts(
   conceptIds: string[],
   context: Context,
 ): Promise<GQLConcept[]> {
-  const response = await Promise.all(
-    conceptIds.map(id => fetch(`/concept-api/v1/concepts/${id}`, context)),
-  );
-  const concepts = await Promise.all(
-    response.map(async concept => {
-      try {
-        return await resolveJson(concept);
-      } catch (e) {
-        return undefined;
-      }
-    }),
-  );
-  return concepts.reduce((acc: GQLConcept[], res: SearchResultJson) => {
-    if (res !== undefined) {
-      acc.push({
-        id: res.id,
-        title: res.title.title,
-        content: res.content.content,
-        metaImage: res.metaImage,
-      });
-    }
-    return acc;
-  }, []);
+  return (
+    await Promise.all(
+      conceptIds.map(async id => {
+        const concept = await fetch(`/concept-api/v1/concepts/${id}`, context);
+        try {
+          const res: SearchResultJson = await resolveJson(concept);
+          const result: GQLConcept = {
+            id: res.id,
+            title: res.title.title,
+            content: res.content.content,
+            metaImage: res.metaImage,
+          };
+          return result;
+        } catch (e) {
+          return undefined;
+        }
+      }),
+    )
+  ).filter(c => !!c);
 }

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -8,7 +8,6 @@
 
 import queryString from 'query-string';
 import { fetch, resolveJson } from '../utils/apiHelpers';
-import logger from '../utils/logger';
 
 export async function searchConcepts(
   searchquery: string,

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -35,3 +35,21 @@ export async function searchConcepts(
     metaImage: res.metaImage,
   }));
 }
+
+export async function fetchConcepts(
+  conceptIds: string[],
+  context: Context,
+): Promise<GQLConcept[]> {
+  const response = await Promise.all(
+    conceptIds.map(id => fetch(`/concept-api/v1/concepts/${id}`, context)),
+  );
+  const concepts = await Promise.all(
+    response.map(concept => resolveJson(concept)),
+  );
+  return concepts.map((res: SearchResultJson) => ({
+    id: res.id,
+    title: res.title.title,
+    content: res.content.content,
+    metaImage: res.metaImage,
+  }));
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -52,4 +52,4 @@ export {
   searchWithoutPagination,
 } from './searchApi';
 export { fetchOembed } from './oembedApi';
-export { searchConcepts } from './conceptApi';
+export { searchConcepts, fetchConcepts } from './conceptApi';

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -84,7 +84,7 @@ export const resolvers = {
       _: any,
       context: Context,
     ): Promise<GQLConcept[]> {
-      return await fetchConcepts(article.conceptIds, context);
+      return fetchConcepts(article.conceptIds, context);
     },
   },
 };

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -12,6 +12,7 @@ import {
   fetchCoreElements,
   fetchCrossSubjectTopicsByCode,
   fetchSubjectTopics,
+  fetchConcepts,
 } from '../api';
 
 export const Query = {
@@ -77,6 +78,13 @@ export const resolvers = {
           (topic: { name: string }) => topic.name === crossSubjectTopic.title,
         )?.path,
       }));
+    },
+    async concepts(
+      article: GQLArticle,
+      _: any,
+      context: Context,
+    ): Promise<GQLConcept[]> {
+      return await fetchConcepts(article.conceptIds, context);
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -265,6 +265,8 @@ export const typeDefs = gql`
       filterIds: String
     ): [CrossSubjectElement]
     oembed: String
+    conceptIds: [String]
+    concepts(conceptIds: [String]): [Concept]
   }
 
   type CompetenceGoal {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -266,7 +266,7 @@ export const typeDefs = gql`
     ): [CrossSubjectElement]
     oembed: String
     conceptIds: [String]
-    concepts(conceptIds: [String]): [Concept]
+    concepts: [Concept]
   }
 
   type CompetenceGoal {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1166,11 +1166,8 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleToConceptsArgs {
-    conceptIds?: Array<string | null>;
-  }
   export interface ArticleToConceptsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: ArticleToConceptsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface GQLArticleRequiredLibraryTypeResolver<TParent = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -120,6 +120,8 @@ declare global {
     coreElements?: Array<GQLCoreElement | null>;
     crossSubjectTopics?: Array<GQLCrossSubjectElement | null>;
     oembed?: string;
+    conceptIds?: Array<string | null>;
+    concepts?: Array<GQLConcept | null>;
   }
   
   export interface GQLArticleRequiredLibrary {
@@ -249,6 +251,13 @@ declare global {
     title: string;
     code?: string;
     path?: string;
+  }
+  
+  export interface GQLConcept {
+    id?: number;
+    title?: string;
+    content?: string;
+    metaImage?: GQLMetaImage;
   }
   
   export interface GQLFilter {
@@ -528,13 +537,6 @@ declare global {
     concepts?: Array<GQLConcept | null>;
   }
   
-  export interface GQLConcept {
-    id?: number;
-    title?: string;
-    content?: string;
-    metaImage?: GQLMetaImage;
-  }
-  
   export interface GQLGroupSearch {
     language?: string;
     resourceType?: string;
@@ -648,6 +650,7 @@ declare global {
     Element?: GQLElementTypeResolver;
     CoreElement?: GQLCoreElementTypeResolver;
     CrossSubjectElement?: GQLCrossSubjectElementTypeResolver;
+    Concept?: GQLConceptTypeResolver;
     Filter?: GQLFilterTypeResolver;
     Learningpath?: GQLLearningpathTypeResolver;
     LearningpathCopyright?: GQLLearningpathCopyrightTypeResolver;
@@ -683,7 +686,6 @@ declare global {
     SearchSuggestion?: GQLSearchSuggestionTypeResolver;
     SuggestOption?: GQLSuggestOptionTypeResolver;
     ConceptResult?: GQLConceptResultTypeResolver;
-    Concept?: GQLConceptTypeResolver;
     GroupSearch?: GQLGroupSearchTypeResolver;
     GroupSearchResult?: GQLGroupSearchResultTypeResolver;
     FrontpageSearch?: GQLFrontpageSearchTypeResolver;
@@ -1060,6 +1062,8 @@ declare global {
     coreElements?: ArticleToCoreElementsResolver<TParent>;
     crossSubjectTopics?: ArticleToCrossSubjectTopicsResolver<TParent>;
     oembed?: ArticleToOembedResolver<TParent>;
+    conceptIds?: ArticleToConceptIdsResolver<TParent>;
+    concepts?: ArticleToConceptsResolver<TParent>;
   }
   
   export interface ArticleToIdResolver<TParent = any, TResult = any> {
@@ -1156,6 +1160,17 @@ declare global {
   
   export interface ArticleToOembedResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleToConceptIdsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleToConceptsArgs {
+    conceptIds?: Array<string | null>;
+  }
+  export interface ArticleToConceptsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: ArticleToConceptsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface GQLArticleRequiredLibraryTypeResolver<TParent = any> {
@@ -1596,6 +1611,29 @@ declare global {
   }
   
   export interface CrossSubjectElementToPathResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLConceptTypeResolver<TParent = any> {
+    id?: ConceptToIdResolver<TParent>;
+    title?: ConceptToTitleResolver<TParent>;
+    content?: ConceptToContentResolver<TParent>;
+    metaImage?: ConceptToMetaImageResolver<TParent>;
+  }
+  
+  export interface ConceptToIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptToTitleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptToContentResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptToMetaImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -2531,29 +2569,6 @@ declare global {
   }
   
   export interface ConceptResultToConceptsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface GQLConceptTypeResolver<TParent = any> {
-    id?: ConceptToIdResolver<TParent>;
-    title?: ConceptToTitleResolver<TParent>;
-    content?: ConceptToContentResolver<TParent>;
-    metaImage?: ConceptToMetaImageResolver<TParent>;
-  }
-  
-  export interface ConceptToIdResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface ConceptToTitleResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface ConceptToContentResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface ConceptToMetaImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
Første steg for å løse NDLANO/Issues#2442

Lagt til et felt `concepts` på artikler, for å holde på relaterte forklaringer som legges til utenfor selve artikkelteksten.

Kan testes i playground med queryen under. Artikkelen skal ha to relaterte forklaringer. 
```
{
  article(id: "133"){
    title
    concepts{
      id
      title
      content
      metaImage{
        url
        alt
      }
    }
  }
}
```
Test uten forklaringer: `id: "299"` får en tom liste for `concepts`.