### PR TITLE
#2416: Stops fetching learningsteps individually and adds support for iframe learningstep type oembed

### DIFF
--- a/src/api/learningpathApi.ts
+++ b/src/api/learningpathApi.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { reject } from 'lodash';
 import { fetch, resolveJson } from '../utils/apiHelpers';
 
 export async function fetchLearningpaths(
@@ -44,6 +45,18 @@ export async function fetchLearningpaths(
   });
 }
 
+interface ApiLearningStep
+  extends Omit<GQLLearningpathStep, 'title' | 'description'> {
+  title: {
+    title: string;
+    language: string;
+  };
+  description: {
+    description: string;
+    language: string;
+  };
+}
+
 export async function fetchLearningpath(
   id: string,
   context: Context,
@@ -53,6 +66,14 @@ export async function fetchLearningpath(
     context,
   );
   const learningpath = await resolveJson(response);
+  const learningsteps = learningpath.learningsteps?.map(
+    (step: ApiLearningStep) => ({
+      ...step,
+      title: step.title?.title || '',
+      description: step.description?.description,
+    }),
+  );
+
   return {
     ...learningpath,
     title: learningpath.title.title,
@@ -63,6 +84,7 @@ export async function fetchLearningpath(
       alt: learningpath.introduction?.introduction || '',
     },
     tags: learningpath.tags?.tags || [],
+    learningsteps,
   };
 }
 

--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -23,13 +23,6 @@ export const Query = {
   ): Promise<GQLLearningpath> {
     return fetchLearningpath(pathId, context);
   },
-  async learningpathStep(
-    _: any,
-    { pathId, stepId }: QueryToLearningpathStepArgs,
-    context: Context,
-  ): Promise<GQLLearningpath> {
-    return fetchLearningpathStep(pathId, stepId, context);
-  },
 };
 
 const buildOembedFromIframeUrl = (url: string): GQLLearningpathStepOembed => {
@@ -75,14 +68,19 @@ export const resolvers = {
       if (
         !learningpathStep.embedUrl ||
         !learningpathStep.embedUrl.url ||
-        learningpathStep.embedUrl.embedType !== 'oembed' ||
+        (learningpathStep.embedUrl.embedType !== 'oembed' &&
+          learningpathStep.embedUrl.embedType !== 'iframe') ||
         !isNDLAEmbedUrl(learningpathStep.embedUrl.url)
       ) {
         return null;
       }
-      const lastPartOfUrl = learningpathStep.embedUrl.url.split('/').pop();
-      if (lastPartOfUrl.includes('resource')) {
-        return fetchResource({ id: `urn:${lastPartOfUrl}` }, context);
+
+      const lastResourceMatch = learningpathStep.embedUrl.url
+        .match(/resource(:\d+)?(:\d+)/g)
+        ?.pop();
+
+      if (lastResourceMatch !== undefined) {
+        return fetchResource({ id: `urn:${lastResourceMatch}` }, context);
       }
       return null;
     },

--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -32,24 +32,17 @@ export const Query = {
   },
 };
 
+const buildOembedFromIframeUrl = (url: string): GQLLearningpathStepOembed => {
+  return {
+    type: 'rich',
+    version: '1.0',
+    height: 800,
+    width: 800,
+    html: `<iframe src="${url}" frameborder="0" allowFullscreen="" />`,
+  };
+};
+
 export const resolvers = {
-  Learningpath: {
-    async learningsteps(
-      learningpath: GQLLearningpath,
-      _: any,
-      context: Context,
-    ): Promise<GQLLearningpathStep[]> {
-      return Promise.all(
-        learningpath.learningsteps.map(step =>
-          fetchLearningpathStep(
-            learningpath.id.toString(),
-            step.id.toString(),
-            context,
-          ),
-        ),
-      );
-    },
-  },
   LearningpathStep: {
     async oembed(
       learningpathStep: GQLLearningpathStep,
@@ -58,6 +51,12 @@ export const resolvers = {
     ): Promise<GQLLearningpathStepOembed> {
       if (!learningpathStep.embedUrl || !learningpathStep.embedUrl.url) {
         return null;
+      }
+      if (
+        learningpathStep.embedUrl &&
+        learningpathStep.embedUrl.embedType === 'iframe'
+      ) {
+        return buildOembedFromIframeUrl(learningpathStep.embedUrl.url);
       }
       if (
         learningpathStep.embedUrl &&

--- a/src/utils/articleHelpers.ts
+++ b/src/utils/articleHelpers.ts
@@ -5,7 +5,7 @@
  */
 
 export function isNDLAEmbedUrl(url: string) {
-  return /^https:\/(.*).ndla.no/.test(url);
+  return /^https:\/(.*).ndla.no/.test(url) || /^http:\/\/localhost/.test(url);
 }
 
 export function getArticleIdFromUrn(urn: string): string {


### PR DESCRIPTION
Relates to NDLANO/Issues#2416
Depends on https://github.com/NDLANO/learningpath-api/pull/169

- Henter alle læringsstegene fra learningpath requesten for å slippe å gjøre en request pr læringssteg
- Lager iframe oembed'en dersom learningsteps har `iframe` type