### PR TITLE
Add suggestions to frontpagesearch

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -564,6 +564,7 @@ export const typeDefs = gql`
   type FrontPageResources {
     results: [FrontpageSearchResult]
     totalCount: Int
+    suggestions: [SuggestionResult]
   }
 
   type FrontpageSearch {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -2663,7 +2663,6 @@ declare global {
   export interface GQLFrontPageResourcesTypeResolver<TParent = any> {
     results?: FrontPageResourcesToResultsResolver<TParent>;
     totalCount?: FrontPageResourcesToTotalCountResolver<TParent>;
-    suggestions?: FrontPageResourcesToSuggestionsResolver<TParent>;
   }
   
   export interface FrontPageResourcesToResultsResolver<TParent = any, TResult = any> {
@@ -2672,10 +2671,6 @@ declare global {
   
   export interface FrontPageResourcesToTotalCountResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-
-  export interface FrontPageResourcesToSuggestionsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>
   }
   
   export interface GQLFrontpageSearchResultTypeResolver<TParent = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -565,6 +565,7 @@ declare global {
   export interface GQLFrontPageResources {
     results?: Array<GQLFrontpageSearchResult | null>;
     totalCount?: number;
+    suggestions?: Array<GQLSuggestionResult | null>;
   }
   
   export interface GQLFrontpageSearchResult {
@@ -2663,6 +2664,7 @@ declare global {
   export interface GQLFrontPageResourcesTypeResolver<TParent = any> {
     results?: FrontPageResourcesToResultsResolver<TParent>;
     totalCount?: FrontPageResourcesToTotalCountResolver<TParent>;
+    suggestions?: FrontPageResourcesToSuggestionsResolver<TParent>;
   }
   
   export interface FrontPageResourcesToResultsResolver<TParent = any, TResult = any> {
@@ -2670,6 +2672,10 @@ declare global {
   }
   
   export interface FrontPageResourcesToTotalCountResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FrontPageResourcesToSuggestionsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -2663,6 +2663,7 @@ declare global {
   export interface GQLFrontPageResourcesTypeResolver<TParent = any> {
     results?: FrontPageResourcesToResultsResolver<TParent>;
     totalCount?: FrontPageResourcesToTotalCountResolver<TParent>;
+    suggestions?: FrontPageResourcesToSuggestionsResolver<TParent>;
   }
   
   export interface FrontPageResourcesToResultsResolver<TParent = any, TResult = any> {
@@ -2671,6 +2672,10 @@ declare global {
   
   export interface FrontPageResourcesToTotalCountResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+
+  export interface FrontPageResourcesToSuggestionsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>
   }
   
   export interface GQLFrontpageSearchResultTypeResolver<TParent = any> {


### PR DESCRIPTION
Relatert til NDLANO/Issues#2499

`suggestions` finnes allerede i frontpageSearch-endepunktet i graphql. La derfor bare `suggestions` inn i type-definisjonen til `FrontPageResources`. Er lite kjent med d.ts-filer, men det så ut som at denne også måtte oppdateres selv om koden kjørte like bra med som uten.

How to test:
1. Kjør graphql-api lokalt.
2. Kjør ndla-frontend lokalt med `yarn start-with-local-graphql`
3. Skriv inn et søkeord på forsiden av ndla-frontend (uten å trykke enter)
4. Sjekk nettverksloggen i inspector og se at mottatt resultat innholder suggestions i både `learningsResources` og `topicResources`

Den nye dataen `suggestions` skal brukes til å vise fram forslag til annet søkeord i søket fra punkt 3.

