### PR TITLE
2558 Vise relatert innhold i læringsstier

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -16,6 +16,7 @@ export async function fetchArticle(
     filterIds?: string;
     subjectId?: string;
     removeRelatedContent?: string;
+    isOembed?: string;
   },
   context: Context,
 ): Promise<GQLArticle> {
@@ -25,8 +26,9 @@ export async function fetchArticle(
   const relatedParam = params.removeRelatedContent
     ? `&removeRelatedContent=${params.removeRelatedContent}`
     : '';
+  const oembedParam = params.isOembed ? `&isOembed=${params.isOembed}` : '';
   const response = await fetch(
-    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${relatedParam}`,
+    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${relatedParam}${oembedParam}`,
     context,
   );
   return resolveJson(response);

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -105,7 +105,7 @@ export const resolvers = {
               filterIds: args.filterIds,
               subjectId: args.subjectId,
               removeRelatedContent: args.removeRelatedContent,
-              isOembed: args.isOembed
+              isOembed: args.isOembed,
             },
             context,
           ).then(article => {

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -92,6 +92,7 @@ export const resolvers = {
         filterIds?: string;
         subjectId?: string;
         removeRelatedContent?: string;
+        isOembed?: string;
       },
       context: Context,
     ): Promise<GQLArticle> {
@@ -104,6 +105,7 @@ export const resolvers = {
               filterIds: args.filterIds,
               subjectId: args.subjectId,
               removeRelatedContent: args.removeRelatedContent,
+              isOembed: args.isOembed
             },
             context,
           ).then(article => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -177,6 +177,7 @@ export const typeDefs = gql`
       filterIds: String
       subjectId: String
       removeRelatedContent: String
+      isOembed: String
     ): Article
     learningpath: Learningpath
     filters: [Filter]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -173,7 +173,12 @@ export const typeDefs = gql`
     paths: [String]
     meta: Meta
     metadata: TaxonomyMetadata
-    article(filterIds: String, subjectId: String, isOembed: String): Article
+    article(
+      filterIds: String
+      subjectId: String
+      removeRelatedContent: String
+      isOembed: String
+    ): Article
     learningpath: Learningpath
     filters: [Filter]
     relevanceId: String

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -176,7 +176,6 @@ export const typeDefs = gql`
     article(
       filterIds: String
       subjectId: String
-      removeRelatedContent: String
       isOembed: String
     ): Article
     learningpath: Learningpath

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -173,11 +173,7 @@ export const typeDefs = gql`
     paths: [String]
     meta: Meta
     metadata: TaxonomyMetadata
-    article(
-      filterIds: String
-      subjectId: String
-      isOembed: String
-    ): Article
+    article(filterIds: String, subjectId: String, isOembed: String): Article
     learningpath: Learningpath
     filters: [Filter]
     relevanceId: String

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1059,7 +1059,6 @@ declare global {
   export interface ResourceToArticleArgs {
     filterIds?: string;
     subjectId?: string;
-    removeRelatedContent?: string;
     isOembed?: string;
   }
   export interface ResourceToArticleResolver<TParent = any, TResult = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1059,6 +1059,7 @@ declare global {
   export interface ResourceToArticleArgs {
     filterIds?: string;
     subjectId?: string;
+    removeRelatedContent?: string;
     isOembed?: string;
   }
   export interface ResourceToArticleResolver<TParent = any, TResult = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1060,6 +1060,7 @@ declare global {
     filterIds?: string;
     subjectId?: string;
     removeRelatedContent?: string;
+    isOembed?: string;
   }
   export interface ResourceToArticleResolver<TParent = any, TResult = any> {
     (parent: TParent, args: ResourceToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;


### PR DESCRIPTION
For NDLANO/Issues#2442
Depends on NDLANO/frontend-packages#792 og NDLANO/article-converter#229

Lagt til `isOembed` parameter til resource query for å sende videre til article-converter sånn at når vi viser relaterte artikler i læringsstier, linkes de til ny fane.