### PR TITLE
2571 APA for referanser

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -15,7 +15,6 @@ export async function fetchArticle(
     articleId: string;
     filterIds?: string;
     subjectId?: string;
-    removeRelatedContent?: string;
     isOembed?: string;
     path?: string;
   },
@@ -24,13 +23,10 @@ export async function fetchArticle(
   const host = localConverter ? 'http://localhost:3100' : '';
   const filterParam = params.filterIds ? `&filters=${params.filterIds}` : '';
   const subjectParam = params.subjectId ? `&subject=${params.subjectId}` : '';
-  const relatedParam = params.removeRelatedContent
-    ? `&removeRelatedContent=${params.removeRelatedContent}`
-    : '';
   const oembedParam = params.isOembed ? `&isOembed=${params.isOembed}` : '';
   const pathParam = params.path ? `&path=${params.path}` : '';
   const response = await fetch(
-    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${relatedParam}${oembedParam}${pathParam}`,
+    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${oembedParam}${pathParam}`,
     context,
   );
   return resolveJson(response);

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -17,6 +17,7 @@ export async function fetchArticle(
     subjectId?: string;
     removeRelatedContent?: string;
     isOembed?: string;
+    path?: string;
   },
   context: Context,
 ): Promise<GQLArticle> {
@@ -27,8 +28,9 @@ export async function fetchArticle(
     ? `&removeRelatedContent=${params.removeRelatedContent}`
     : '';
   const oembedParam = params.isOembed ? `&isOembed=${params.isOembed}` : '';
+  const pathParam = params.path ? `&path=${params.path}` : '';
   const response = await fetch(
-    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${relatedParam}${oembedParam}`,
+    `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${relatedParam}${oembedParam}${pathParam}`,
     context,
   );
   return resolveJson(response);

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -18,14 +18,7 @@ import {
 export const Query = {
   async article(
     _: any,
-    {
-      id,
-      filterIds,
-      subjectId,
-      removeRelatedContent,
-      isOembed,
-      path,
-    }: QueryToArticleArgs,
+    { id, filterIds, subjectId, isOembed, path }: QueryToArticleArgs,
     context: Context,
   ): Promise<GQLArticle> {
     return fetchArticle(
@@ -33,7 +26,6 @@ export const Query = {
         articleId: id,
         filterIds,
         subjectId,
-        removeRelatedContent,
         isOembed,
         path,
       },

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -24,11 +24,19 @@ export const Query = {
       subjectId,
       removeRelatedContent,
       isOembed,
+      path,
     }: QueryToArticleArgs,
     context: Context,
   ): Promise<GQLArticle> {
     return fetchArticle(
-      { articleId: id, filterIds, subjectId, removeRelatedContent, isOembed },
+      {
+        articleId: id,
+        filterIds,
+        subjectId,
+        removeRelatedContent,
+        isOembed,
+        path,
+      },
       context,
     );
   },

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -106,6 +106,7 @@ export const resolvers = {
               subjectId: args.subjectId,
               removeRelatedContent: args.removeRelatedContent,
               isOembed: args.isOembed,
+              path: resource.path,
             },
             context,
           ).then(article => {

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -91,7 +91,6 @@ export const resolvers = {
       args: {
         filterIds?: string;
         subjectId?: string;
-        removeRelatedContent?: string;
         isOembed?: string;
       },
       context: Context,
@@ -104,7 +103,6 @@ export const resolvers = {
               articleId,
               filterIds: args.filterIds,
               subjectId: args.subjectId,
-              removeRelatedContent: args.removeRelatedContent,
               isOembed: args.isOembed,
               path: resource.path,
             },

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -62,6 +62,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
               articleId,
               filterIds: args.filterIds,
               subjectId: args.subjectId,
+              path: topic.path,
             },
             context,
           ).then(article => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -248,16 +248,18 @@ export const typeDefs = gql`
     src: String!
     altText: String!
     copyright: Copyright!
+    copyText: String!
   }
 
   type AudioLicense {
     title: String!
     src: String!
     copyright: Copyright!
+    copyText: String!
   }
 
   type BrightcoveIframe {
-    src: String!
+    src: String! 
     height: Int!
     width: Int!
   }
@@ -271,18 +273,21 @@ export const typeDefs = gql`
     iframe: BrightcoveIframe
     copyright: Copyright!
     uploadDate: String
+    copyText: String 
   }
 
   type H5pLicense {
     title: String!
     src: String
     copyright: Copyright!
+    copyText: String
   }
 
-  type ConceptLicense {
+  type ConceptLicense { 
     title: String!
     src: String
     copyright: Copyright
+    copyText: String
   }
 
   type ArticleMetaData {
@@ -292,6 +297,7 @@ export const typeDefs = gql`
     brightcoves: [BrightcoveLicense]
     h5ps: [H5pLicense]
     concepts: [ConceptLicense]
+    copyText: String
   }
 
   type Article {
@@ -302,7 +308,7 @@ export const typeDefs = gql`
     content: String!
     created: String!
     updated: String!
-    published: String!
+    published: String! 
     visualElement: String
     metaImage: MetaImage
     metaDescription: String!
@@ -310,7 +316,7 @@ export const typeDefs = gql`
     oldNdlaUrl: String
     requiredLibraries: [ArticleRequiredLibrary]
     metaData: ArticleMetaData
-    supportedLanguages: [String]
+    supportedLanguages: [String] 
     copyright: Copyright!
     tags: [String]
     grepCodes: [String]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -243,14 +243,14 @@ export const typeDefs = gql`
     src: String!
     altText: String!
     copyright: Copyright!
-    copyText: String!
+    copyText: String
   }
 
   type AudioLicense {
     title: String!
     src: String!
     copyright: Copyright!
-    copyText: String!
+    copyText: String
   }
 
   type BrightcoveIframe {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -174,12 +174,7 @@ export const typeDefs = gql`
     paths: [String]
     meta: Meta
     metadata: TaxonomyMetadata
-    article(
-      filterIds: String
-      subjectId: String
-      removeRelatedContent: String
-      isOembed: String
-    ): Article
+    article(filterIds: String, subjectId: String, isOembed: String): Article
     learningpath: Learningpath
     filters: [Filter]
     relevanceId: String
@@ -653,7 +648,6 @@ export const typeDefs = gql`
       id: String!
       filterIds: String
       subjectId: String
-      removeRelatedContent: String
       isOembed: String
       path: String
     ): Article

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -649,6 +649,7 @@ export const typeDefs = gql`
       subjectId: String
       removeRelatedContent: String
       isOembed: String
+      path: String
     ): Article
     subject(id: String!): Subject
     subjectpage(id: String!): SubjectPage

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -259,7 +259,7 @@ export const typeDefs = gql`
   }
 
   type BrightcoveIframe {
-    src: String! 
+    src: String!
     height: Int!
     width: Int!
   }
@@ -273,7 +273,7 @@ export const typeDefs = gql`
     iframe: BrightcoveIframe
     copyright: Copyright!
     uploadDate: String
-    copyText: String 
+    copyText: String
   }
 
   type H5pLicense {
@@ -283,7 +283,7 @@ export const typeDefs = gql`
     copyText: String
   }
 
-  type ConceptLicense { 
+  type ConceptLicense {
     title: String!
     src: String
     copyright: Copyright
@@ -308,7 +308,7 @@ export const typeDefs = gql`
     content: String!
     created: String!
     updated: String!
-    published: String! 
+    published: String!
     visualElement: String
     metaImage: MetaImage
     metaDescription: String!
@@ -316,7 +316,7 @@ export const typeDefs = gql`
     oldNdlaUrl: String
     requiredLibraries: [ArticleRequiredLibrary]
     metaData: ArticleMetaData
-    supportedLanguages: [String] 
+    supportedLanguages: [String]
     copyright: Copyright!
     tags: [String]
     grepCodes: [String]

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -824,7 +824,6 @@ declare global {
     id: string;
     filterIds?: string;
     subjectId?: string;
-    removeRelatedContent?: string;
     isOembed?: string;
     path?: string;
   }
@@ -1065,7 +1064,6 @@ declare global {
   export interface ResourceToArticleArgs {
     filterIds?: string;
     subjectId?: string;
-    removeRelatedContent?: string;
     isOembed?: string;
   }
   export interface ResourceToArticleResolver<TParent = any, TResult = any> {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -159,7 +159,7 @@ declare global {
     src: string;
     altText: string;
     copyright: GQLCopyright;
-    copyText: string;
+    copyText?: string;
   }
   
   export interface GQLCopyright {
@@ -185,7 +185,7 @@ declare global {
     title: string;
     src: string;
     copyright: GQLCopyright;
-    copyText: string;
+    copyText?: string;
   }
   
   export interface GQLBrightcoveLicense {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -820,6 +820,7 @@ declare global {
     subjectId?: string;
     removeRelatedContent?: string;
     isOembed?: string;
+    path?: string;
   }
   export interface QueryToArticleResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToArticleArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -141,6 +141,7 @@ declare global {
     brightcoves?: Array<GQLBrightcoveLicense | null>;
     h5ps?: Array<GQLH5pLicense | null>;
     concepts?: Array<GQLConceptLicense | null>;
+    copyText?: string;
   }
   
   export interface GQLFootNote {
@@ -158,6 +159,7 @@ declare global {
     src: string;
     altText: string;
     copyright: GQLCopyright;
+    copyText: string;
   }
   
   export interface GQLCopyright {
@@ -183,6 +185,7 @@ declare global {
     title: string;
     src: string;
     copyright: GQLCopyright;
+    copyText: string;
   }
   
   export interface GQLBrightcoveLicense {
@@ -194,6 +197,7 @@ declare global {
     iframe?: GQLBrightcoveIframe;
     copyright: GQLCopyright;
     uploadDate?: string;
+    copyText?: string;
   }
   
   export interface GQLBrightcoveIframe {
@@ -206,12 +210,14 @@ declare global {
     title: string;
     src?: string;
     copyright: GQLCopyright;
+    copyText?: string;
   }
   
   export interface GQLConceptLicense {
     title: string;
     src?: string;
     copyright?: GQLCopyright;
+    copyText?: string;
   }
   
   export interface GQLCompetenceGoal {
@@ -1309,6 +1315,7 @@ declare global {
     brightcoves?: ArticleMetaDataToBrightcovesResolver<TParent>;
     h5ps?: ArticleMetaDataToH5psResolver<TParent>;
     concepts?: ArticleMetaDataToConceptsResolver<TParent>;
+    copyText?: ArticleMetaDataToCopyTextResolver<TParent>;
   }
   
   export interface ArticleMetaDataToFootnotesResolver<TParent = any, TResult = any> {
@@ -1332,6 +1339,10 @@ declare global {
   }
   
   export interface ArticleMetaDataToConceptsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1378,6 +1389,7 @@ declare global {
     src?: ImageLicenseToSrcResolver<TParent>;
     altText?: ImageLicenseToAltTextResolver<TParent>;
     copyright?: ImageLicenseToCopyrightResolver<TParent>;
+    copyText?: ImageLicenseToCopyTextResolver<TParent>;
   }
   
   export interface ImageLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1393,6 +1405,10 @@ declare global {
   }
   
   export interface ImageLicenseToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageLicenseToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1459,6 +1475,7 @@ declare global {
     title?: AudioLicenseToTitleResolver<TParent>;
     src?: AudioLicenseToSrcResolver<TParent>;
     copyright?: AudioLicenseToCopyrightResolver<TParent>;
+    copyText?: AudioLicenseToCopyTextResolver<TParent>;
   }
   
   export interface AudioLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1473,6 +1490,10 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface AudioLicenseToCopyTextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLBrightcoveLicenseTypeResolver<TParent = any> {
     title?: BrightcoveLicenseToTitleResolver<TParent>;
     description?: BrightcoveLicenseToDescriptionResolver<TParent>;
@@ -1482,6 +1503,7 @@ declare global {
     iframe?: BrightcoveLicenseToIframeResolver<TParent>;
     copyright?: BrightcoveLicenseToCopyrightResolver<TParent>;
     uploadDate?: BrightcoveLicenseToUploadDateResolver<TParent>;
+    copyText?: BrightcoveLicenseToCopyTextResolver<TParent>;
   }
   
   export interface BrightcoveLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1516,6 +1538,10 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface BrightcoveLicenseToCopyTextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLBrightcoveIframeTypeResolver<TParent = any> {
     src?: BrightcoveIframeToSrcResolver<TParent>;
     height?: BrightcoveIframeToHeightResolver<TParent>;
@@ -1538,6 +1564,7 @@ declare global {
     title?: H5pLicenseToTitleResolver<TParent>;
     src?: H5pLicenseToSrcResolver<TParent>;
     copyright?: H5pLicenseToCopyrightResolver<TParent>;
+    copyText?: H5pLicenseToCopyTextResolver<TParent>;
   }
   
   export interface H5pLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1552,10 +1579,15 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface H5pLicenseToCopyTextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLConceptLicenseTypeResolver<TParent = any> {
     title?: ConceptLicenseToTitleResolver<TParent>;
     src?: ConceptLicenseToSrcResolver<TParent>;
     copyright?: ConceptLicenseToCopyrightResolver<TParent>;
+    copyText?: ConceptLicenseToCopyTextResolver<TParent>;
   }
   
   export interface ConceptLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1567,6 +1599,10 @@ declare global {
   }
   
   export interface ConceptLicenseToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptLicenseToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -76,7 +76,7 @@ function externalsToH5pMetaData(obj: any) {
   // looking for externals array
   if (obj?.metaData?.h5ps?.length) {
     const h5pArray: any[] = [];
-    obj.metaData.h5ps.map((i: { h5p: any; url: string }) => {
+    obj.metaData.h5ps.map((i: { h5p: any; url: string; copyText: string }) => {
       if (i && i.h5p) {
         // this element have h5p object
         let copyrightElement = {
@@ -104,6 +104,7 @@ function externalsToH5pMetaData(obj: any) {
           copyright: copyrightElement,
           title: i.h5p.title || '',
           src: i.url || '',
+          copyText: i.copyText,
         });
       }
       return i;


### PR DESCRIPTION
For NDLANO/Issues#2571 og NDLANO/article-converter#235

Lagt til path som parameter til article-converter for å bruke det som kilde til referansekopiering av ressurser (bilder, lyder etc.) i artikler. Og lagt til copyData som en del av metadata for å få den samme kopieringsteksten alle steder man kopierer referanser.

Fra ndla-frontend må den kun sendes ved bruk av plainArticleQuery, ellers har man tilgang på path fra topic og resource.