### PR TITLE
2508 visual element license info

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -164,11 +164,10 @@ export async function fetchDetailedConcept(
     const data = parsedElement('embed').data();
     detailedConcept.visualElement = data;
     if (data?.resource === 'image') {
-      const image = await fetchImage(data.resourceId, context);
-      detailedConcept.visualElement.image = {
-        imageUrl: image.src,
-        contentType: image.contentType,
-      };
+      detailedConcept.visualElement.image = await fetchImage(
+        data.resourceId,
+        context,
+      );
     } else if (data?.resource === 'brightcove') {
       detailedConcept.visualElement.url = `https://players.brightcove.net/${data.account}/${data.player}_default/index.html?videoId=${data.videoid}`;
       const license: GQLBrightcoveLicense = await fetchVisualElementLicense(

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -208,7 +208,7 @@ export async function fetchListingPage(
   );
   const subjects = (subjectResults.filter(
     result => result.status === 'fulfilled',
-  ) as PromiseFulfilledResult<GQLSubject>[]).map(res => res.value);
+  ) as Array<PromiseFulfilledResult<GQLSubject>>).map(res => res.value);
 
   const tags = await resolveJson(
     await fetch(`/concept-api/v1/concepts/tags/`, context),

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -209,7 +209,7 @@ export async function fetchListingPage(
   const subjects = (subjectResults.filter(
     result => result.status === 'fulfilled',
   ) as PromiseFulfilledResult<GQLSubject>[]).map(res => res.value);
-  
+
   const tags = await resolveJson(
     await fetch(`/concept-api/v1/concepts/tags/`, context),
   );

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -176,6 +176,7 @@ export async function fetchDetailedConcept(
         context,
       );
       detailedConcept.visualElement.copyright = license.copyright;
+      detailedConcept.visualElement.copyText = license.copyText;
       detailedConcept.visualElement.thumbnail = license.cover;
     } else if (data?.resource === 'h5p') {
       const visualElementOembed = await fetchOembed(data.url, context);
@@ -186,6 +187,7 @@ export async function fetchDetailedConcept(
         context,
       );
       detailedConcept.visualElement.copyright = license.copyright;
+      detailedConcept.visualElement.copyText = license.copyText;
       detailedConcept.visualElement.thumbnail = license.thumbnail;
     } else if (data?.resource === 'external') {
       const visualElementOembed = await fetchOembed(data.url, context);
@@ -201,9 +203,13 @@ export async function fetchListingPage(
   const subjectIds: string[] = await resolveJson(
     await fetch(`/concept-api/v1/concepts/subjects/`, context),
   );
-  const subjects = await Promise.all(
+  const subjectResults = await Promise.allSettled(
     subjectIds.map(id => fetchSubject(id, context)),
   );
+  const subjects = (subjectResults.filter(
+    result => result.status === 'fulfilled',
+  ) as PromiseFulfilledResult<GQLSubject>[]).map(res => res.value);
+  
   const tags = await resolveJson(
     await fetch(`/concept-api/v1/concepts/tags/`, context),
   );

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -584,6 +584,7 @@ export const typeDefs = gql`
     upperLeftY: Int
     focalX: Int
     focalY: Int
+    copyright: Copyright
   }
 
   type ListingPage {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -245,6 +245,7 @@ export const typeDefs = gql`
     src: String!
     altText: String!
     copyright: Copyright!
+    contentType: String
   }
 
   type AudioLicense {
@@ -557,11 +558,6 @@ export const typeDefs = gql`
     relevance: String
   }
 
-  type VisualElementImage {
-    imageUrl: String
-    contentType: String
-  }
-
   type VisualElementOembed {
     title: String
     html: String
@@ -578,7 +574,7 @@ export const typeDefs = gql`
     player: String
     videoid: String
     thumbnail: String
-    image: VisualElementImage
+    image: ImageLicense
     oembed: VisualElementOembed
     lowerRightX: Int
     lowerRightY: Int
@@ -613,7 +609,6 @@ export const typeDefs = gql`
     content: String
     created: String
     tags: [String]
-    metaImage: MetaImage
     image: ImageLicense
     subjectIds: [String]
     articleIds: [String]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -588,6 +588,7 @@ export const typeDefs = gql`
     focalX: Int
     focalY: Int
     copyright: Copyright
+    copyText: String
   }
 
   type ListingPage {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -273,6 +273,7 @@ export const typeDefs = gql`
   type H5pLicense {
     title: String!
     src: String
+    thumbnail: String
     copyright: Copyright!
   }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -577,6 +577,7 @@ export const typeDefs = gql`
     account: String
     player: String
     videoid: String
+    thumbnail: String
     image: VisualElementImage
     oembed: VisualElementOembed
     lowerRightX: Int

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -608,6 +608,7 @@ declare global {
     account?: string;
     player?: string;
     videoid?: string;
+    thumbnail?: string;
     image?: GQLVisualElementImage;
     oembed?: GQLVisualElementOembed;
     lowerRightX?: number;
@@ -2978,6 +2979,7 @@ declare global {
     account?: VisualElementToAccountResolver<TParent>;
     player?: VisualElementToPlayerResolver<TParent>;
     videoid?: VisualElementToVideoidResolver<TParent>;
+    thumbnail?: VisualElementToThumbnailResolver<TParent>;
     image?: VisualElementToImageResolver<TParent>;
     oembed?: VisualElementToOembedResolver<TParent>;
     lowerRightX?: VisualElementToLowerRightXResolver<TParent>;
@@ -3018,6 +3020,10 @@ declare global {
   }
   
   export interface VisualElementToVideoidResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToThumbnailResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -615,6 +615,7 @@ declare global {
     upperLeftY?: number;
     focalX?: number;
     focalY?: number;
+    copyright?: GQLCopyright;
   }
   
   export interface GQLVisualElementImage {
@@ -2979,6 +2980,7 @@ declare global {
     upperLeftY?: VisualElementToUpperLeftYResolver<TParent>;
     focalX?: VisualElementToFocalXResolver<TParent>;
     focalY?: VisualElementToFocalYResolver<TParent>;
+    copyright?: VisualElementToCopyrightResolver<TParent>;
   }
   
   export interface VisualElementToResourceResolver<TParent = any, TResult = any> {
@@ -3042,6 +3044,10 @@ declare global {
   }
   
   export interface VisualElementToFocalYResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToCopyrightResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -160,6 +160,7 @@ declare global {
     src: string;
     altText: string;
     copyright: GQLCopyright;
+    contentType?: string;
   }
   
   export interface GQLCopyright {
@@ -590,7 +591,6 @@ declare global {
     content?: string;
     created?: string;
     tags?: Array<string | null>;
-    metaImage?: GQLMetaImage;
     image?: GQLImageLicense;
     subjectIds?: Array<string | null>;
     articleIds?: Array<string | null>;
@@ -609,7 +609,7 @@ declare global {
     player?: string;
     videoid?: string;
     thumbnail?: string;
-    image?: GQLVisualElementImage;
+    image?: GQLImageLicense;
     oembed?: GQLVisualElementOembed;
     lowerRightX?: number;
     lowerRightY?: number;
@@ -618,11 +618,6 @@ declare global {
     focalX?: number;
     focalY?: number;
     copyright?: GQLCopyright;
-  }
-  
-  export interface GQLVisualElementImage {
-    imageUrl?: string;
-    contentType?: string;
   }
   
   export interface GQLVisualElementOembed {
@@ -821,7 +816,6 @@ declare global {
     ListingPage?: GQLListingPageTypeResolver;
     DetailedConcept?: GQLDetailedConceptTypeResolver;
     VisualElement?: GQLVisualElementTypeResolver;
-    VisualElementImage?: GQLVisualElementImageTypeResolver;
     VisualElementOembed?: GQLVisualElementOembedTypeResolver;
     FrontpageSearch?: GQLFrontpageSearchTypeResolver;
     FrontPageResources?: GQLFrontPageResourcesTypeResolver;
@@ -1457,6 +1451,7 @@ declare global {
     src?: ImageLicenseToSrcResolver<TParent>;
     altText?: ImageLicenseToAltTextResolver<TParent>;
     copyright?: ImageLicenseToCopyrightResolver<TParent>;
+    contentType?: ImageLicenseToContentTypeResolver<TParent>;
   }
   
   export interface ImageLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -1472,6 +1467,10 @@ declare global {
   }
   
   export interface ImageLicenseToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageLicenseToContentTypeResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -2913,7 +2912,6 @@ declare global {
     content?: DetailedConceptToContentResolver<TParent>;
     created?: DetailedConceptToCreatedResolver<TParent>;
     tags?: DetailedConceptToTagsResolver<TParent>;
-    metaImage?: DetailedConceptToMetaImageResolver<TParent>;
     image?: DetailedConceptToImageResolver<TParent>;
     subjectIds?: DetailedConceptToSubjectIdsResolver<TParent>;
     articleIds?: DetailedConceptToArticleIdsResolver<TParent>;
@@ -2939,10 +2937,6 @@ declare global {
   }
   
   export interface DetailedConceptToTagsResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface DetailedConceptToMetaImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -3060,19 +3054,6 @@ declare global {
   }
   
   export interface VisualElementToCopyrightResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface GQLVisualElementImageTypeResolver<TParent = any> {
-    imageUrl?: VisualElementImageToImageUrlResolver<TParent>;
-    contentType?: VisualElementImageToContentTypeResolver<TParent>;
-  }
-  
-  export interface VisualElementImageToImageUrlResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementImageToContentTypeResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -207,6 +207,7 @@ declare global {
   export interface GQLH5pLicense {
     title: string;
     src?: string;
+    thumbnail?: string;
     copyright: GQLCopyright;
   }
   
@@ -1614,6 +1615,7 @@ declare global {
   export interface GQLH5pLicenseTypeResolver<TParent = any> {
     title?: H5pLicenseToTitleResolver<TParent>;
     src?: H5pLicenseToSrcResolver<TParent>;
+    thumbnail?: H5pLicenseToThumbnailResolver<TParent>;
     copyright?: H5pLicenseToCopyrightResolver<TParent>;
   }
   
@@ -1622,6 +1624,10 @@ declare global {
   }
   
   export interface H5pLicenseToSrcResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface H5pLicenseToThumbnailResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -626,6 +626,7 @@ declare global {
     focalX?: number;
     focalY?: number;
     copyright?: GQLCopyright;
+    copyText?: string;
   }
   
   export interface GQLVisualElementOembed {
@@ -3031,6 +3032,7 @@ declare global {
     focalX?: VisualElementToFocalXResolver<TParent>;
     focalY?: VisualElementToFocalYResolver<TParent>;
     copyright?: VisualElementToCopyrightResolver<TParent>;
+    copyText?: VisualElementToCopyTextResolver<TParent>;
   }
   
   export interface VisualElementToResourceResolver<TParent = any, TResult = any> {
@@ -3102,6 +3104,10 @@ declare global {
   }
   
   export interface VisualElementToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -76,40 +76,42 @@ function externalsToH5pMetaData(obj: any) {
   // looking for externals array
   if (obj?.metaData?.h5ps?.length) {
     const h5pArray: any[] = [];
-    obj.metaData.h5ps.map((i: { h5p: any; assets: any[]; url: string; copyText: string }) => {
-      if (i && i.h5p) {
-        // this element have h5p object
-        let copyrightElement = {
-          license: {
-            license: licenseFixer(
-              i.h5p.license || '',
-              i.h5p.licenseVersion || '4.0',
-            ),
-            url: i.h5p.source || '',
-            description: i.h5p.licenseExtras || '',
-          },
-          creators: new Array(),
-          processors: new Array(),
-          rightsholders: i.h5p.authors
-            ? i.h5p.authors.map((author: { role: any; name?: string }) => {
-                return {
-                  type: roleMapper(author.role || ''),
-                  name: author.name || '',
-                };
-              })
-            : [],
-          origin: i.h5p.source || '',
-        };
-        h5pArray.push({
-          copyright: copyrightElement,
-          title: i.h5p.title || '',
-          src: i.url || '',
-          thumbnail: i.h5p.thumbnail || i.assets?.[0]?.thumbnail,
-          copyText: i.copyText,
-        });
-      }
-      return i;
-    });
+    obj.metaData.h5ps.map(
+      (i: { h5p: any; assets: any[]; url: string; copyText: string }) => {
+        if (i && i.h5p) {
+          // this element have h5p object
+          let copyrightElement = {
+            license: {
+              license: licenseFixer(
+                i.h5p.license || '',
+                i.h5p.licenseVersion || '4.0',
+              ),
+              url: i.h5p.source || '',
+              description: i.h5p.licenseExtras || '',
+            },
+            creators: new Array(),
+            processors: new Array(),
+            rightsholders: i.h5p.authors
+              ? i.h5p.authors.map((author: { role: any; name?: string }) => {
+                  return {
+                    type: roleMapper(author.role || ''),
+                    name: author.name || '',
+                  };
+                })
+              : [],
+            origin: i.h5p.source || '',
+          };
+          h5pArray.push({
+            copyright: copyrightElement,
+            title: i.h5p.title || '',
+            src: i.url || '',
+            thumbnail: i.h5p.thumbnail || i.assets?.[0]?.thumbnail,
+            copyText: i.copyText,
+          });
+        }
+        return i;
+      },
+    );
 
     // adding h5p array
     if (h5pArray.length > 0) {

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -76,7 +76,7 @@ function externalsToH5pMetaData(obj: any) {
   // looking for externals array
   if (obj?.metaData?.h5ps?.length) {
     const h5pArray: any[] = [];
-    obj.metaData.h5ps.map((i: { h5p: any; url: string }) => {
+    obj.metaData.h5ps.map((i: { h5p: any; assets: any[]; url: string }) => {
       if (i && i.h5p) {
         // this element have h5p object
         let copyrightElement = {
@@ -104,6 +104,7 @@ function externalsToH5pMetaData(obj: any) {
           copyright: copyrightElement,
           title: i.h5p.title || '',
           src: i.url || '',
+          thumbnail: i.h5p.thumbnail || i.assets?.[0]?.thumbnail,
         });
       }
       return i;


### PR DESCRIPTION
Depends on https://github.com/NDLANO/article-converter/pull/242

Henter lisensinformasjon for concept fra article-converter.

Test:
Hent ut copyright til et h5p eller brightcove visuelt element med detailedConcept
Eks: 
```
detailedConcept(id: "2493") {
    visualElement {
    resource
      copyright {
        license {
          license
        }
        creators {
          name
        }
      }
    }
  }
```