### PR TITLE
Support returning _something_ for listingPage.

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -167,7 +167,9 @@ export async function fetchListingPage(
     await fetch(`/concept-api/v1/concepts/subjects/`, context),
   );
   const subjects = await Promise.all(
-    subjectIds.map(id => fetchSubject(id, context)),
+    subjectIds.map(id =>
+      fetchSubject({ id, options: { ignore404: true, id } }, context),
+    ),
   );
   const tags = await resolveJson(
     await fetch(`/concept-api/v1/concepts/tags/`, context),

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -196,7 +196,7 @@ export async function searchWithoutPagination(
     }
   }
   const response = await Promise.all(requests);
-  const allResultsJson = await Promise.all(response.map(resolveJson));
+  const allResultsJson = await Promise.all(response.map(r => resolveJson(r)));
   allResultsJson.push(firstPageJson);
   return {
     results: allResultsJson.flatMap(json =>

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -84,7 +84,7 @@ export async function fetchSubject(
     `/${context.taxonomyUrl}/v1/subjects/${id}?language=${context.language}`,
     context,
   );
-  return resolveJson(response);
+  return resolveJson(response, { ignore404: true, id });
 }
 
 export async function fetchSubjectTopics(

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { fetch, resolveJson } from '../utils/apiHelpers';
+import { fetch, resolveJson, ResponseOptions } from '../utils/apiHelpers';
 
 interface Topic {
   id: string;
@@ -77,14 +77,14 @@ export async function fetchSubjects(context: Context): Promise<GQLSubject[]> {
 }
 
 export async function fetchSubject(
-  id: string,
+  params: { id: string; options?: ResponseOptions },
   context: Context,
 ): Promise<GQLSubject> {
   const response = await fetch(
-    `/${context.taxonomyUrl}/v1/subjects/${id}?language=${context.language}`,
+    `/${context.taxonomyUrl}/v1/subjects/${params.id}?language=${context.language}`,
     context,
   );
-  return resolveJson(response, { ignore404: true, id });
+  return resolveJson(response, params.options);
 }
 
 export async function fetchSubjectTopics(

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -139,7 +139,8 @@ export const resolvers = {
               .slice(1, -1)
               .map(async id => {
                 if (id.includes('subject:')) {
-                  return (await fetchSubject(`urn:${id}`, context)).name;
+                  return (await fetchSubject({ id: `urn:${id}` }, context))
+                    .name;
                 } else if (id.includes('topic:')) {
                   return (await fetchTopic({ id: `urn:${id}` }, context)).name;
                 }

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -188,7 +188,8 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
               .slice(1)
               .map(async id => {
                 if (id.includes('subject:')) {
-                  return (await fetchSubject(`urn:${id}`, context)).name;
+                  return (await fetchSubject({ id: `urn:${id}` }, context))
+                    .name;
                 } else if (id.includes('topic:')) {
                   return (await fetchTopic({ id: `urn:${id}` }, context)).name;
                 }

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -53,12 +53,28 @@ async function fetchHelper(
 
 export const fetch = fetchHelper;
 
-export async function resolveJson(response: Response): Promise<any> {
+export interface ResponseOptions {
+  id: string;
+  ignore404: boolean;
+}
+
+export async function resolveJson(
+  response: Response,
+  options?: ResponseOptions,
+): Promise<any> {
   const { status, ok, url, statusText } = response;
 
   if (status === 204) {
     // nothing to resolve
     return;
+  }
+
+  if (status === 404 && options?.ignore404) {
+    // Handle deleted subjects
+    return {
+      id: options.id,
+      name: options.id,
+    };
   }
 
   const json = await response.json();

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -70,10 +70,10 @@ export async function resolveJson(
   }
 
   if (status === 404 && options?.ignore404) {
-    // Handle deleted subjects
+    // Handle deleted subjects. Filter subjects without name in listing-frontend
     return {
       id: options.id,
-      name: options.id,
+      name: '',
     };
   }
 


### PR DESCRIPTION
Ikkje så pent, men listing-frontend funker ikkje lenger på grunn av at alle subjects returnerer 404. Dette gjør at sida fungerer, men viser id i lista over subjects som kan filteres på.

Test:
1. Kjør graphql lokalt. 
2. Kjør listing-frontend med `yarn start-with-local-graphql`
3. Det skal vises forklaringer, men filtrering på fag viser kun ider.