### PR TITLE
Gjør det mulig å hente alternative topics sammen med et topic for å r…

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -27,7 +27,7 @@ function findPrimaryPath(
   paths: string[],
   subjectId: string,
 ): string | undefined {
-  return paths.find(path => path.split('/')[1] === removeUrn(subjectId));
+  return paths?.find(path => path.split('/')[1] === removeUrn(subjectId));
 }
 
 export async function fetchResource(
@@ -175,21 +175,7 @@ export async function fetchTopicResources(
     }
   });
 
-  // Only check filters from subject containing topic. Should be fixed in tax.
-  const topicSubject = `urn:${topic.path
-    .split('/')
-    .find(token => token.includes('subject'))}`;
   const suplResources = resources.filter(resource => {
-    // when filters are deleted from tax, remove until END
-    const subjectFilters = resource.filters?.filter(
-      filter => filter.subjectId === topicSubject,
-    );
-    if (subjectFilters?.length > 0) {
-      return subjectFilters?.find(
-        filter => filter.relevanceId === 'urn:relevance:supplementary',
-      );
-    }
-    // END
     return resource.relevanceId === 'urn:relevance:supplementary';
   });
   const coreResources = resources.filter(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -200,6 +200,7 @@ export const typeDefs = gql`
     pathTopics: [[Topic]]
     coreResources(filterIds: String, subjectId: String): [Resource]
     supplementaryResources(filterIds: String, subjectId: String): [Resource]
+    alternateTopics: [Topic]
     breadcrumbs: [[String]]
   }
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -369,6 +369,7 @@ declare global {
     pathTopics?: Array<Array<GQLTopic | null> | null>;
     coreResources?: Array<GQLResource | null>;
     supplementaryResources?: Array<GQLResource | null>;
+    alternateTopics?: Array<GQLTopic | null>;
     breadcrumbs?: Array<Array<string | null> | null>;
   }
   
@@ -2186,6 +2187,7 @@ declare global {
     pathTopics?: TopicToPathTopicsResolver<TParent>;
     coreResources?: TopicToCoreResourcesResolver<TParent>;
     supplementaryResources?: TopicToSupplementaryResourcesResolver<TParent>;
+    alternateTopics?: TopicToAlternateTopicsResolver<TParent>;
     breadcrumbs?: TopicToBreadcrumbsResolver<TParent>;
   }
   
@@ -2266,6 +2268,10 @@ declare global {
   }
   export interface TopicToSupplementaryResourcesResolver<TParent = any, TResult = any> {
     (parent: TParent, args: TopicToSupplementaryResourcesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToAlternateTopicsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface TopicToBreadcrumbsResolver<TParent = any, TResult = any> {


### PR DESCRIPTION
…edusere antall kall.

No gjøres det to graphql-kall for kvar gong SubjectPage kalles. Ved å legge til alternateTopics i første spørring får du det du trenger i det første kallet.

Test:
Kjør opp lokalt og kjør følgende spørring i playground:

```
{
  topic(id: "urn:topic:3:1:165209") {
    id
    name
    path
    alternateTopics {
      id
      name
      path
      breadcrumbs
    }
  }
}
```

Du skal få to innslag i alternateTopics. Dersom du forsøker med id fra en av dei andre vil du ikkje få svar.