### PR TITLE
Fetch html with cheerio to avoid string splitting

### DIFF
--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import cheerio from 'cheerio';
 import {
   fetchResource,
   fetchResourceTypes,
@@ -110,7 +111,10 @@ export const resolvers = {
           ).then(article => {
             return Object.assign({}, article, {
               oembed: fetchOembed(`${ndlaUrl}${resource.path}`, context).then(
-                oembed => oembed.html.split('"')[3],
+                oembed => {
+                  const parsed = cheerio.load(oembed.html);
+                  return parsed('iframe').attr('src');
+                },
               ),
             });
           }),


### PR DESCRIPTION
Dagens kode feiler for artikler som har " i tittelen. Det unngås ved at vi plukker ut src-atrtibuttet fra iframe-taggen direkte-