### PR TITLE
2583 nytt design verktøykassa

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -10,6 +10,11 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 import { localConverter } from '../config';
 import { getArticleIdFromUrn } from '../utils/articleHelpers';
 import cheerio from 'cheerio';
+import {
+  fetchImage,
+  fetchOembed,
+  fetchVisualElementLicense,
+} from '../utils/visualelementHelpers';
 
 export async function fetchArticle(
   params: {
@@ -155,40 +160,4 @@ export async function fetchMovieMeta(
     };
   }
   return null;
-}
-
-async function fetchImage(imageId: string, context: Context) {
-  const imageResponse = await fetch(`/image-api/v2/images/${imageId}`, context);
-  const image = await resolveJson(imageResponse);
-  return {
-    title: image.title.title,
-    src: image.imageUrl,
-    altText: image.alttext.alttext,
-    contentType: image.contentType,
-    copyright: image.copyright,
-  };
-}
-
-async function fetchVisualElementLicense(
-  visualElement: string,
-  resource: string,
-  context: Context,
-): Promise<GQLBrightcoveLicense | GQLH5pLicense> {
-  const host = localConverter ? 'http://localhost:3100' : '';
-  const metaDataResponse = await fetch(
-    encodeURI(
-      `${host}/article-converter/json/${context.language}/meta-data?embed=${visualElement}`,
-    ),
-    context,
-  );
-  const metaData = await resolveJson(metaDataResponse);
-  return metaData.metaData[resource][0];
-}
-
-export async function fetchOembed(
-  url: string,
-  context: Context,
-): Promise<GQLLearningpathStepOembed> {
-  const response = await fetch(`/oembed-proxy/v1/oembed?url=${url}`, context);
-  return resolveJson(response);
 }

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -30,17 +30,14 @@ export async function fetchArticle(
     `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${filterParam}${subjectParam}${oembedParam}${pathParam}`,
     context,
   );
-  
+
   const concept = await resolveJson(response);
   if (concept.visualElement) {
     const parsedElement = cheerio.load(concept.visualElement.visualElement);
     const data = parsedElement('embed').data();
     concept.visualElement = data;
     if (data?.resource === 'image') {
-      concept.visualElement.image = await fetchImage(
-        data.resourceId,
-        context,
-      );
+      concept.visualElement.image = await fetchImage(data.resourceId, context);
     } else if (data?.resource === 'brightcove') {
       concept.visualElement.url = `https://players.brightcove.net/${data.account}/${data.player}_default/index.html?videoId=${data.videoid}`;
       const license: GQLBrightcoveLicense = await fetchVisualElementLicense(
@@ -68,9 +65,8 @@ export async function fetchArticle(
     }
   }
 
-  return new Promise((resolve,reject) => {
-    console.log(concept.visualElement);
-    resolve(concept)
+  return new Promise((resolve, reject) => {
+    resolve(concept);
   });
 }
 
@@ -150,7 +146,6 @@ export async function fetchMovieMeta(
   return null;
 }
 
-
 async function fetchImage(imageId: string, context: Context) {
   const imageResponse = await fetch(`/image-api/v2/images/${imageId}`, context);
   const image = await resolveJson(imageResponse);
@@ -178,7 +173,6 @@ async function fetchVisualElementLicense(
   const metaData = await resolveJson(metaDataResponse);
   return metaData.metaData[resource][0];
 }
-
 
 export async function fetchOembed(
   url: string,

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -32,50 +32,52 @@ export async function fetchArticle(
   );
 
   const article = await resolveJson(response);
-  let transposedArticle: GQLArticle = {
-    ...article
-  }
-  if (transposedArticle.visualElement) {
+  let transposedarticle: GQLArticle = {
+    ...article,
+  };
+  if (transposedarticle.visualElement) {
     const parsedElement = cheerio.load(article.visualElement.visualElement);
     const data = parsedElement('embed').data();
-    transposedArticle.visualElement = {
+    transposedarticle.visualElement = {
       ...data,
-      embed : article.visualElement.visualElement,
+      embed: article.visualElement.visualElement,
       language: article.visualElement.language,
-    } 
+    };
 
     if (data?.resource === 'image') {
-      transposedArticle.visualElement.image = await fetchImage(data.resourceId, context);
+      transposedarticle.visualElement.image = await fetchImage(
+        data.resourceId,
+        context,
+      );
     } else if (data?.resource === 'brightcove') {
-      transposedArticle.visualElement.url = `https://players.brightcove.net/${data.account}/${data.player}_default/index.html?videoId=${data.videoid}`;
+      transposedarticle.visualElement.url = `https://players.brightcove.net/${data.account}/${data.player}_default/index.html?videoId=${data.videoid}`;
       const license: GQLBrightcoveLicense = await fetchVisualElementLicense(
         article.visualElement.visualElement,
         'brightcoves',
         context,
       );
-      transposedArticle.visualElement.copyright = license.copyright;
-      transposedArticle.visualElement.copyText = license.copyText;
-      transposedArticle.visualElement.thumbnail = license.cover;
+      transposedarticle.visualElement.copyright = license.copyright;
+      transposedarticle.visualElement.copyText = license.copyText;
+      transposedarticle.visualElement.thumbnail = license.cover;
     } else if (data?.resource === 'h5p') {
       const visualElementOembed = await fetchOembed(data.url, context);
-      transposedArticle.visualElement.oembed = visualElementOembed;
+      transposedarticle.visualElement.oembed = visualElementOembed;
       const license: GQLH5pLicense = await fetchVisualElementLicense(
         article.visualElement.visualElement,
         'h5ps',
         context,
       );
-      transposedArticle.visualElement.copyright = license.copyright;
-      transposedArticle.visualElement.copyText = license.copyText;
-      transposedArticle.visualElement.thumbnail = license.thumbnail;
+      transposedarticle.visualElement.copyright = license.copyright;
+      transposedarticle.visualElement.copyText = license.copyText;
+      transposedarticle.visualElement.thumbnail = license.thumbnail;
     } else if (data?.resource === 'external') {
       const visualElementOembed = await fetchOembed(data.url, context);
-      transposedArticle.visualElement.oembed = visualElementOembed;
+      transposedarticle.visualElement.oembed = visualElementOembed;
     }
   }
-  
 
-  return new Promise((resolve, _reject) => {
-    resolve(transposedArticle);
+  return new Promise((resolve, reject) => {
+    resolve(transposedarticle);
   });
 }
 

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -13,6 +13,10 @@ import { fetchSubject } from './taxonomyApi';
 import { fetchArticlesPage } from './articleApi';
 import { fetchOembed } from './oembedApi';
 import { localConverter } from '../config';
+import {
+  fetchImage,
+  fetchVisualElementLicense,
+} from '../utils/visualelementHelpers';
 
 interface ConceptSearchResultJson extends SearchResultJson {
   tags?: {
@@ -29,34 +33,6 @@ interface ConceptSearchResultJson extends SearchResultJson {
   articleIds?: string[];
   subjectIds?: string[];
   created: string;
-}
-
-async function fetchImage(imageId: string, context: Context) {
-  const imageResponse = await fetch(`/image-api/v2/images/${imageId}`, context);
-  const image = await resolveJson(imageResponse);
-  return {
-    title: image.title.title,
-    src: image.imageUrl,
-    altText: image.alttext.alttext,
-    contentType: image.contentType,
-    copyright: image.copyright,
-  };
-}
-
-async function fetchVisualElementLicense(
-  visualElement: string,
-  resource: string,
-  context: Context,
-): Promise<GQLBrightcoveLicense | GQLH5pLicense> {
-  const host = localConverter ? 'http://localhost:3100' : '';
-  const metaDataResponse = await fetch(
-    encodeURI(
-      `${host}/article-converter/json/${context.language}/meta-data?embed=${visualElement}`,
-    ),
-    context,
-  );
-  const metaData = await resolveJson(metaDataResponse);
-  return metaData.metaData[resource][0];
 }
 
 export async function searchConcepts(

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -313,7 +313,7 @@ export const typeDefs = gql`
     created: String!
     updated: String!
     published: String!
-    visualElement: String
+    visualElement: VisualElement
     metaImage: MetaImage
     metaDescription: String!
     articleType: String!
@@ -333,6 +333,10 @@ export const typeDefs = gql`
     oembed: String
     conceptIds: [String]
     concepts: [Concept]
+  }
+
+  type embedVisualelement {
+    visualElement: VisualElement
   }
 
   type CompetenceGoal {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -727,12 +727,12 @@ export const typeDefs = gql`
     frontpage: Frontpage
     filters: [SubjectFilter!]
     competenceGoals(
-      codes: [String!]
+      codes: [String]
       nodeId: String
       language: String
     ): [CompetenceGoal!]
     competenceGoal(code: String!, language: String): CompetenceGoal
-    coreElements(codes: [String!], language: String): [CoreElement!]
+    coreElements(codes: [String], language: String): [CoreElement!]
     coreElement(code: String!, language: String): CoreElement
     search(
       query: String
@@ -750,7 +750,7 @@ export const typeDefs = gql`
       languageFilter: String
       relevance: String
       grepCodes: String
-      aggregatePaths: [String!]
+      aggregatePaths: [String]
     ): Search
     resourceTypes: [ResourceTypeDefinition!]
     groupSearch(
@@ -764,7 +764,7 @@ export const typeDefs = gql`
       language: String
       fallback: String
       grepCodes: String
-      aggregatePaths: [String!]
+      aggregatePaths: [String]
     ): [GroupSearch!]
     listingPage: ListingPage
     concepts(ids: [String!]): [Concept!]

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -25,7 +25,7 @@ export const typeDefs = gql`
   }
 
   type Tags {
-    tags: [String]
+    tags: [String!]
     language: String!
   }
 
@@ -50,7 +50,7 @@ export const typeDefs = gql`
     audioFile: AudioFile!
     copyright: Copyright!
     tags: Tags
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     audioType: String!
     podcastMeta: PodcastMeta
   }
@@ -60,19 +60,19 @@ export const typeDefs = gql`
     page: Int
     language: String
     totalCount: Int
-    results: [Audio]
+    results: [Audio!]
   }
 
   type ResourceTypeDefinition {
     id: String!
     name: String!
-    subtypes: [ResourceTypeDefinition]
+    subtypes: [ResourceTypeDefinition!]
   }
 
   type ResourceType {
     id: String!
     name: String!
-    resources(topicId: String!): [Resource]
+    resources(topicId: String!): [Resource!]
   }
 
   type MetaImage {
@@ -112,7 +112,7 @@ export const typeDefs = gql`
     metaUrl: String
     revision: Int
     status: String
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     type: String
     article: Article
     resource: Resource
@@ -127,7 +127,7 @@ export const typeDefs = gql`
 
   type LearningpathCopyright {
     license: License
-    contributors: [Contributor]
+    contributors: [Contributor!]
   }
 
   type Learningpath {
@@ -139,10 +139,10 @@ export const typeDefs = gql`
     canEdit: Boolean
     verificationStatus: String
     lastUpdated: String
-    tags: [String]
-    supportedLanguages: [String]
+    tags: [String!]
+    supportedLanguages: [String!]
     isBasedOn: Int
-    learningsteps: [LearningpathStep]
+    learningsteps: [LearningpathStep!]
     metaUrl: String
     revision: Int
     learningstepUrl: String
@@ -151,7 +151,7 @@ export const typeDefs = gql`
   }
 
   type TaxonomyMetadata {
-    grepCodes: [String]
+    grepCodes: [String!]
     visible: Boolean
     customFields: JSON
   }
@@ -161,11 +161,11 @@ export const typeDefs = gql`
     name: String!
     contentUri: String
     path: String
-    paths: [String]
+    paths: [String!]
     meta: Meta
     metadata: TaxonomyMetadata
     article(filterIds: String, subjectId: String): Article
-    filters: [Filter]
+    filters: [Filter!]
     relevanceId: String
     rank: Int
   }
@@ -175,17 +175,17 @@ export const typeDefs = gql`
     name: String!
     contentUri: String
     path: String
-    paths: [String]
+    paths: [String!]
     meta: Meta
     metadata: TaxonomyMetadata
     article(filterIds: String, subjectId: String, isOembed: String): Article
     learningpath: Learningpath
-    filters: [Filter]
+    filters: [Filter!]
     rank: Int
     relevanceId: String
-    resourceTypes: [ResourceType]
-    parentTopics: [Topic]
-    breadcrumbs: [[String]]
+    resourceTypes: [ResourceType!]
+    parentTopics: [Topic!]
+    breadcrumbs: [[String!]!]
   }
 
   type Topic implements TaxonomyEntity {
@@ -193,21 +193,21 @@ export const typeDefs = gql`
     name: String!
     contentUri: String
     path: String
-    paths: [String]
+    paths: [String!]
     meta: Meta
     metadata: TaxonomyMetadata
     article(filterIds: String, subjectId: String): Article
-    filters: [Filter]
+    filters: [Filter!]
     rank: Int
     relevanceId: String
     isPrimary: Boolean
     parent: String
-    subtopics(filterIds: String): [Topic]
-    pathTopics: [[Topic]]
-    coreResources(filterIds: String, subjectId: String): [Resource]
-    supplementaryResources(filterIds: String, subjectId: String): [Resource]
-    alternateTopics: [Topic]
-    breadcrumbs: [[String]]
+    subtopics(filterIds: String): [Topic!]
+    pathTopics: [[Topic!]!]
+    coreResources(filterIds: String, subjectId: String): [Resource!]
+    supplementaryResources(filterIds: String, subjectId: String): [Resource!]
+    alternateTopics: [Topic!]
+    breadcrumbs: [[String!]!]
   }
 
   type License {
@@ -223,9 +223,9 @@ export const typeDefs = gql`
 
   type Copyright {
     license: License
-    creators: [Contributor]
-    processors: [Contributor]
-    rightsholders: [Contributor]
+    creators: [Contributor!]
+    processors: [Contributor!]
+    rightsholders: [Contributor!]
     origin: String
   }
 
@@ -239,7 +239,7 @@ export const typeDefs = gql`
     ref: Int!
     title: String!
     year: String!
-    authors: [String]!
+    authors: [String!]!
     edition: String
     publisher: String
     url: String
@@ -295,12 +295,12 @@ export const typeDefs = gql`
   }
 
   type ArticleMetaData {
-    footnotes: [FootNote]
-    images: [ImageLicense]
-    audios: [AudioLicense]
-    brightcoves: [BrightcoveLicense]
-    h5ps: [H5pLicense]
-    concepts: [ConceptLicense]
+    footnotes: [FootNote!]
+    images: [ImageLicense!]
+    audios: [AudioLicense!]
+    brightcoves: [BrightcoveLicense!]
+    h5ps: [H5pLicense!]
+    concepts: [ConceptLicense!]
     copyText: String
   }
 
@@ -318,21 +318,21 @@ export const typeDefs = gql`
     metaDescription: String!
     articleType: String!
     oldNdlaUrl: String
-    requiredLibraries: [ArticleRequiredLibrary]
+    requiredLibraries: [ArticleRequiredLibrary!]
     metaData: ArticleMetaData
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     copyright: Copyright!
-    tags: [String]
-    grepCodes: [String]
-    competenceGoals: [CompetenceGoal]
-    coreElements: [CoreElement]
+    tags: [String!]
+    grepCodes: [String!]
+    competenceGoals: [CompetenceGoal!]
+    coreElements: [CoreElement!]
     crossSubjectTopics(
       subjectId: String
       filterIds: String
-    ): [CrossSubjectElement]
+    ): [CrossSubjectElement!]
     oembed: String
-    conceptIds: [String]
-    concepts: [Concept]
+    conceptIds: [String!]
+    concepts: [Concept!]
   }
 
   type embedVisualelement {
@@ -350,10 +350,10 @@ export const typeDefs = gql`
     curriculum: Reference
     competenceGoalSetCode: String
     competenceGoalSet: Reference
-    crossSubjectTopicsCodes: [Element]
-    crossSubjectTopics: [Element]
-    coreElementsCodes: [Element]
-    coreElements: [Element]
+    crossSubjectTopicsCodes: [Element!]
+    crossSubjectTopics: [Element!]
+    coreElementsCodes: [Element!]
+    coreElements: [Element!]
   }
 
   type CoreElement {
@@ -406,8 +406,8 @@ export const typeDefs = gql`
   }
 
   type Frontpage {
-    topical: [Resource]
-    categories: [Category]
+    topical: [Resource!]
+    categories: [Category!]
   }
 
   type SubjectPageVisualElement {
@@ -431,15 +431,15 @@ export const typeDefs = gql`
 
   type SubjectPage {
     topical(subjectId: String): TaxonomyEntity
-    mostRead(subjectId: String): [TaxonomyEntity]
+    mostRead(subjectId: String): [TaxonomyEntity!]
     banner: SubjectPageBanner
     id: Int!
     name: String
     facebook: String
-    editorsChoices(subjectId: String): [TaxonomyEntity]
-    latestContent(subjectId: String): [TaxonomyEntity]
+    editorsChoices(subjectId: String): [TaxonomyEntity!]
+    latestContent(subjectId: String): [TaxonomyEntity!]
     about: SubjectPageAbout
-    goTo: [ResourceTypeDefinition]
+    goTo: [ResourceTypeDefinition!]
     metaDescription: String
     layout: String
     twitter: String
@@ -454,14 +454,14 @@ export const typeDefs = gql`
 
   type FilmFrontpage {
     name: String
-    about: [FilmPageAbout]
-    movieThemes: [MovieTheme]
-    slideShow: [Movie]
+    about: [FilmPageAbout!]
+    movieThemes: [MovieTheme!]
+    slideShow: [Movie!]
   }
 
   type MovieTheme {
-    name: [Name]
-    movies: [Movie]
+    name: [Name!]
+    movies: [Movie!]
   }
 
   type Name {
@@ -474,7 +474,7 @@ export const typeDefs = gql`
     title: String
     metaImage: MetaImage
     metaDescription: String
-    resourceTypes: [ResourceType]
+    resourceTypes: [ResourceType!]
     path: String
   }
 
@@ -486,11 +486,11 @@ export const typeDefs = gql`
 
   type MoviePath {
     path: String
-    paths: [String]
+    paths: [String!]
   }
 
   type MovieResourceTypes {
-    resourceTypes: [ResourceType]
+    resourceTypes: [ResourceType!]
   }
 
   type Subject {
@@ -499,68 +499,68 @@ export const typeDefs = gql`
     name: String!
     path: String!
     metadata: TaxonomyMetadata
-    filters: [SubjectFilter]
-    frontpageFilters: [SubjectFilter]
+    filters: [SubjectFilter!]
+    frontpageFilters: [SubjectFilter!]
     subjectpage: SubjectPage
-    topics(all: Boolean, filterIds: String): [Topic]
+    topics(all: Boolean, filterIds: String): [Topic!]
   }
 
   interface SearchResult {
     id: Int!
     title: String
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     url: String
     metaDescription: String
     metaImage: MetaImage
     contentType: String
-    traits: [String]
-    contexts: [SearchContext]
+    traits: [String!]
+    contexts: [SearchContext!]
   }
 
   type ArticleSearchResult implements SearchResult {
     id: Int!
     title: String
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     url: String
     metaDescription: String
     metaImage: MetaImage
     contentType: String
-    traits: [String]
-    contexts: [SearchContext]
+    traits: [String!]
+    contexts: [SearchContext!]
   }
 
   type LearningpathSearchResult implements SearchResult {
     id: Int!
     title: String
-    supportedLanguages: [String]
+    supportedLanguages: [String!]
     url: String
     metaDescription: String
     metaImage: MetaImage
     contentType: String
-    traits: [String]
-    contexts: [SearchContext]
+    traits: [String!]
+    contexts: [SearchContext!]
   }
 
   type FrontpageSearchResult {
     id: String!
     name: String
-    resourceTypes: [SearchContextResourceTypes]
+    resourceTypes: [SearchContextResourceTypes!]
     subject: String
     path: String
-    filters: [SearchContextFilter]
+    filters: [SearchContextFilter!]
   }
 
   type SearchContext {
-    breadcrumbs: [String]
+    breadcrumbs: [String!]
     learningResourceType: String
-    resourceTypes: [SearchContextResourceTypes]
+    resourceTypes: [SearchContextResourceTypes!]
     subject: String
     subjectId: String
     relevance: String
     path: String
     id: String
     language: String
-    filters: [SearchContextFilter]
+    filters: [SearchContextFilter!]
   }
 
   type SearchContextResourceTypes {
@@ -601,23 +601,25 @@ export const typeDefs = gql`
     focalY: Int
     copyright: Copyright
     copyText: String
+    embed: String
+    language: String
   }
 
   type ListingPage {
-    subjects: [Subject]
-    tags: [String]
+    subjects: [Subject!]
+    tags: [String!]
   }
 
   type ConceptResult {
     totalCount: Int
-    concepts: [Concept]
+    concepts: [Concept!]
   }
 
   type Concept {
     id: Int
     title: String
     content: String
-    tags: [String]
+    tags: [String!]
     metaImage: MetaImage
   }
 
@@ -626,11 +628,11 @@ export const typeDefs = gql`
     title: String
     content: String
     created: String
-    tags: [String]
+    tags: [String!]
     image: ImageLicense
-    subjectIds: [String]
-    articleIds: [String]
-    articles: [Meta]
+    subjectIds: [String!]
+    articleIds: [String!]
+    articles: [Meta!]
     visualElement: VisualElement
     copyright: Copyright
   }
@@ -640,22 +642,22 @@ export const typeDefs = gql`
     page: Int
     language: String
     totalCount: Int
-    results: [SearchResult]
-    suggestions: [SuggestionResult]
-    aggregations: [AggregationResult]
+    results: [SearchResult!]
+    suggestions: [SuggestionResult!]
+    aggregations: [AggregationResult!]
     concepts: ConceptResult
   }
 
   type SuggestionResult {
     name: String
-    suggestions: [SearchSuggestion]
+    suggestions: [SearchSuggestion!]
   }
 
   type AggregationResult {
     field: String
     sumOtherDocCount: Int
     docCountErrorUpperBound: Int
-    values: [BucketResult]
+    values: [BucketResult!]
   }
 
   type BucketResult {
@@ -667,7 +669,7 @@ export const typeDefs = gql`
     text: String
     offset: Int
     length: Int
-    options: [SuggestOption]
+    options: [SuggestOption!]
   }
 
   type SuggestOption {
@@ -680,24 +682,24 @@ export const typeDefs = gql`
     path: String!
     name: String!
     ingress: String
-    traits: [String]
-    contexts: [SearchContext]
+    traits: [String!]
+    contexts: [SearchContext!]
     metaImage: MetaImage
   }
 
   type GroupSearch {
     language: String
     resourceType: String
-    resources: [GroupSearchResult]
-    suggestions: [SuggestionResult]
-    aggregations: [AggregationResult]
+    resources: [GroupSearchResult!]
+    suggestions: [SuggestionResult!]
+    aggregations: [AggregationResult!]
     totalCount: Int
   }
 
   type FrontPageResources {
-    results: [FrontpageSearchResult]
+    results: [FrontpageSearchResult!]
     totalCount: Int
-    suggestions: [SuggestionResult]
+    suggestions: [SuggestionResult!]
   }
 
   type FrontpageSearch {
@@ -719,18 +721,18 @@ export const typeDefs = gql`
     filmfrontpage: FilmFrontpage
     learningpath(pathId: String!): Learningpath
     learningpathStep(pathId: String!, stepId: String!): LearningpathStep
-    subjects: [Subject]
+    subjects: [Subject!]
     topic(id: String!, subjectId: String): Topic
-    topics(contentUri: String, filterVisible: Boolean): [Topic]
+    topics(contentUri: String, filterVisible: Boolean): [Topic!]
     frontpage: Frontpage
-    filters: [SubjectFilter]
+    filters: [SubjectFilter!]
     competenceGoals(
-      codes: [String]
+      codes: [String!]
       nodeId: String
       language: String
-    ): [CompetenceGoal]
+    ): [CompetenceGoal!]
     competenceGoal(code: String!, language: String): CompetenceGoal
-    coreElements(codes: [String], language: String): [CoreElement]
+    coreElements(codes: [String!], language: String): [CoreElement!]
     coreElement(code: String!, language: String): CoreElement
     search(
       query: String
@@ -748,9 +750,9 @@ export const typeDefs = gql`
       languageFilter: String
       relevance: String
       grepCodes: String
-      aggregatePaths: [String]
+      aggregatePaths: [String!]
     ): Search
-    resourceTypes: [ResourceTypeDefinition]
+    resourceTypes: [ResourceTypeDefinition!]
     groupSearch(
       query: String
       subjects: String
@@ -762,10 +764,10 @@ export const typeDefs = gql`
       language: String
       fallback: String
       grepCodes: String
-      aggregatePaths: [String]
-    ): [GroupSearch]
+      aggregatePaths: [String!]
+    ): [GroupSearch!]
     listingPage: ListingPage
-    concepts(ids: [String]): [Concept]
+    concepts(ids: [String!]): [Concept!]
     detailedConcept(id: String): DetailedConcept
     conceptSearch(
       query: String

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -117,7 +117,7 @@ declare global {
     created: string;
     updated: string;
     published: string;
-    visualElement?: string;
+    visualElement?: GQLVisualElement;
     metaImage?: GQLMetaImage;
     metaDescription: string;
     articleType: string;
@@ -136,30 +136,26 @@ declare global {
     concepts?: Array<GQLConcept | null>;
   }
   
-  export interface GQLArticleRequiredLibrary {
-    name: string;
-    url: string;
-    mediaType: string;
-  }
-  
-  export interface GQLArticleMetaData {
-    footnotes?: Array<GQLFootNote | null>;
-    images?: Array<GQLImageLicense | null>;
-    audios?: Array<GQLAudioLicense | null>;
-    brightcoves?: Array<GQLBrightcoveLicense | null>;
-    h5ps?: Array<GQLH5pLicense | null>;
-    concepts?: Array<GQLConceptLicense | null>;
-    copyText?: string;
-  }
-  
-  export interface GQLFootNote {
-    ref: number;
-    title: string;
-    year: string;
-    authors: Array<string | null>;
-    edition?: string;
-    publisher?: string;
+  export interface GQLVisualElement {
+    resource?: string;
+    resourceId?: string;
+    title?: string;
     url?: string;
+    alt?: string;
+    account?: string;
+    player?: string;
+    videoid?: string;
+    thumbnail?: string;
+    image?: GQLImageLicense;
+    oembed?: GQLVisualElementOembed;
+    lowerRightX?: number;
+    lowerRightY?: number;
+    upperLeftX?: number;
+    upperLeftY?: number;
+    focalX?: number;
+    focalY?: number;
+    copyright?: GQLCopyright;
+    copyText?: string;
   }
   
   export interface GQLImageLicense {
@@ -188,6 +184,38 @@ declare global {
   export interface GQLContributor {
     type: string;
     name: string;
+  }
+  
+  export interface GQLVisualElementOembed {
+    title?: string;
+    html?: string;
+    fullscreen?: boolean;
+  }
+  
+  export interface GQLArticleRequiredLibrary {
+    name: string;
+    url: string;
+    mediaType: string;
+  }
+  
+  export interface GQLArticleMetaData {
+    footnotes?: Array<GQLFootNote | null>;
+    images?: Array<GQLImageLicense | null>;
+    audios?: Array<GQLAudioLicense | null>;
+    brightcoves?: Array<GQLBrightcoveLicense | null>;
+    h5ps?: Array<GQLH5pLicense | null>;
+    concepts?: Array<GQLConceptLicense | null>;
+    copyText?: string;
+  }
+  
+  export interface GQLFootNote {
+    ref: number;
+    title: string;
+    year: string;
+    authors: Array<string | null>;
+    edition?: string;
+    publisher?: string;
+    url?: string;
   }
   
   export interface GQLAudioLicense {
@@ -388,7 +416,7 @@ declare global {
     filters?: Array<GQLSubjectFilter | null>;
     frontpageFilters?: Array<GQLSubjectFilter | null>;
     subjectpage?: GQLSubjectPage;
-    topics?: Array<GQLTopic | null>;
+    topics?: Array<GQLTopic>;
   }
   
   export interface GQLSubjectFilter {
@@ -615,34 +643,6 @@ declare global {
     copyright?: GQLCopyright;
   }
   
-  export interface GQLVisualElement {
-    resource?: string;
-    resourceId?: string;
-    title?: string;
-    url?: string;
-    alt?: string;
-    account?: string;
-    player?: string;
-    videoid?: string;
-    thumbnail?: string;
-    image?: GQLImageLicense;
-    oembed?: GQLVisualElementOembed;
-    lowerRightX?: number;
-    lowerRightY?: number;
-    upperLeftX?: number;
-    upperLeftY?: number;
-    focalX?: number;
-    focalY?: number;
-    copyright?: GQLCopyright;
-    copyText?: string;
-  }
-  
-  export interface GQLVisualElementOembed {
-    title?: string;
-    html?: string;
-    fullscreen?: boolean;
-  }
-  
   export interface GQLFrontpageSearch {
     topicResources?: GQLFrontPageResources;
     learningResources?: GQLFrontPageResources;
@@ -714,6 +714,10 @@ declare global {
     results?: Array<GQLAudio | null>;
   }
   
+  export interface GQLembedVisualelement {
+    visualElement?: GQLVisualElement;
+  }
+  
   export interface GQLMovieMeta {
     title?: string;
     metaImage?: GQLMetaImage;
@@ -775,13 +779,15 @@ declare global {
     TaxonomyMetadata?: GQLTaxonomyMetadataTypeResolver;
     JSON?: GraphQLScalarType;
     Article?: GQLArticleTypeResolver;
-    ArticleRequiredLibrary?: GQLArticleRequiredLibraryTypeResolver;
-    ArticleMetaData?: GQLArticleMetaDataTypeResolver;
-    FootNote?: GQLFootNoteTypeResolver;
+    VisualElement?: GQLVisualElementTypeResolver;
     ImageLicense?: GQLImageLicenseTypeResolver;
     Copyright?: GQLCopyrightTypeResolver;
     License?: GQLLicenseTypeResolver;
     Contributor?: GQLContributorTypeResolver;
+    VisualElementOembed?: GQLVisualElementOembedTypeResolver;
+    ArticleRequiredLibrary?: GQLArticleRequiredLibraryTypeResolver;
+    ArticleMetaData?: GQLArticleMetaDataTypeResolver;
+    FootNote?: GQLFootNoteTypeResolver;
     AudioLicense?: GQLAudioLicenseTypeResolver;
     BrightcoveLicense?: GQLBrightcoveLicenseTypeResolver;
     BrightcoveIframe?: GQLBrightcoveIframeTypeResolver;
@@ -834,8 +840,6 @@ declare global {
     GroupSearchResult?: GQLGroupSearchResultTypeResolver;
     ListingPage?: GQLListingPageTypeResolver;
     DetailedConcept?: GQLDetailedConceptTypeResolver;
-    VisualElement?: GQLVisualElementTypeResolver;
-    VisualElementOembed?: GQLVisualElementOembedTypeResolver;
     FrontpageSearch?: GQLFrontpageSearchTypeResolver;
     FrontPageResources?: GQLFrontPageResourcesTypeResolver;
     FrontpageSearchResult?: GQLFrontpageSearchResultTypeResolver;
@@ -846,6 +850,7 @@ declare global {
     PodcastMeta?: GQLPodcastMetaTypeResolver;
     CoverPhoto?: GQLCoverPhotoTypeResolver;
     AudioSearch?: GQLAudioSearchTypeResolver;
+    embedVisualelement?: GQLembedVisualelementTypeResolver;
     MovieMeta?: GQLMovieMetaTypeResolver;
     MoviePath?: GQLMoviePathTypeResolver;
     MovieResourceTypes?: GQLMovieResourceTypesTypeResolver;
@@ -1392,97 +1397,101 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLArticleRequiredLibraryTypeResolver<TParent = any> {
-    name?: ArticleRequiredLibraryToNameResolver<TParent>;
-    url?: ArticleRequiredLibraryToUrlResolver<TParent>;
-    mediaType?: ArticleRequiredLibraryToMediaTypeResolver<TParent>;
+  export interface GQLVisualElementTypeResolver<TParent = any> {
+    resource?: VisualElementToResourceResolver<TParent>;
+    resourceId?: VisualElementToResourceIdResolver<TParent>;
+    title?: VisualElementToTitleResolver<TParent>;
+    url?: VisualElementToUrlResolver<TParent>;
+    alt?: VisualElementToAltResolver<TParent>;
+    account?: VisualElementToAccountResolver<TParent>;
+    player?: VisualElementToPlayerResolver<TParent>;
+    videoid?: VisualElementToVideoidResolver<TParent>;
+    thumbnail?: VisualElementToThumbnailResolver<TParent>;
+    image?: VisualElementToImageResolver<TParent>;
+    oembed?: VisualElementToOembedResolver<TParent>;
+    lowerRightX?: VisualElementToLowerRightXResolver<TParent>;
+    lowerRightY?: VisualElementToLowerRightYResolver<TParent>;
+    upperLeftX?: VisualElementToUpperLeftXResolver<TParent>;
+    upperLeftY?: VisualElementToUpperLeftYResolver<TParent>;
+    focalX?: VisualElementToFocalXResolver<TParent>;
+    focalY?: VisualElementToFocalYResolver<TParent>;
+    copyright?: VisualElementToCopyrightResolver<TParent>;
+    copyText?: VisualElementToCopyTextResolver<TParent>;
   }
   
-  export interface ArticleRequiredLibraryToNameResolver<TParent = any, TResult = any> {
+  export interface VisualElementToResourceResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleRequiredLibraryToUrlResolver<TParent = any, TResult = any> {
+  export interface VisualElementToResourceIdResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleRequiredLibraryToMediaTypeResolver<TParent = any, TResult = any> {
+  export interface VisualElementToTitleResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLArticleMetaDataTypeResolver<TParent = any> {
-    footnotes?: ArticleMetaDataToFootnotesResolver<TParent>;
-    images?: ArticleMetaDataToImagesResolver<TParent>;
-    audios?: ArticleMetaDataToAudiosResolver<TParent>;
-    brightcoves?: ArticleMetaDataToBrightcovesResolver<TParent>;
-    h5ps?: ArticleMetaDataToH5psResolver<TParent>;
-    concepts?: ArticleMetaDataToConceptsResolver<TParent>;
-    copyText?: ArticleMetaDataToCopyTextResolver<TParent>;
-  }
-  
-  export interface ArticleMetaDataToFootnotesResolver<TParent = any, TResult = any> {
+  export interface VisualElementToUrlResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToImagesResolver<TParent = any, TResult = any> {
+  export interface VisualElementToAltResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToAudiosResolver<TParent = any, TResult = any> {
+  export interface VisualElementToAccountResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToBrightcovesResolver<TParent = any, TResult = any> {
+  export interface VisualElementToPlayerResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToH5psResolver<TParent = any, TResult = any> {
+  export interface VisualElementToVideoidResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToConceptsResolver<TParent = any, TResult = any> {
+  export interface VisualElementToThumbnailResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ArticleMetaDataToCopyTextResolver<TParent = any, TResult = any> {
+  export interface VisualElementToImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLFootNoteTypeResolver<TParent = any> {
-    ref?: FootNoteToRefResolver<TParent>;
-    title?: FootNoteToTitleResolver<TParent>;
-    year?: FootNoteToYearResolver<TParent>;
-    authors?: FootNoteToAuthorsResolver<TParent>;
-    edition?: FootNoteToEditionResolver<TParent>;
-    publisher?: FootNoteToPublisherResolver<TParent>;
-    url?: FootNoteToUrlResolver<TParent>;
-  }
-  
-  export interface FootNoteToRefResolver<TParent = any, TResult = any> {
+  export interface VisualElementToOembedResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToTitleResolver<TParent = any, TResult = any> {
+  export interface VisualElementToLowerRightXResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToYearResolver<TParent = any, TResult = any> {
+  export interface VisualElementToLowerRightYResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToAuthorsResolver<TParent = any, TResult = any> {
+  export interface VisualElementToUpperLeftXResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToEditionResolver<TParent = any, TResult = any> {
+  export interface VisualElementToUpperLeftYResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToPublisherResolver<TParent = any, TResult = any> {
+  export interface VisualElementToFocalXResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FootNoteToUrlResolver<TParent = any, TResult = any> {
+  export interface VisualElementToFocalYResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1575,6 +1584,118 @@ declare global {
   }
   
   export interface ContributorToNameResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLVisualElementOembedTypeResolver<TParent = any> {
+    title?: VisualElementOembedToTitleResolver<TParent>;
+    html?: VisualElementOembedToHtmlResolver<TParent>;
+    fullscreen?: VisualElementOembedToFullscreenResolver<TParent>;
+  }
+  
+  export interface VisualElementOembedToTitleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementOembedToHtmlResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementOembedToFullscreenResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLArticleRequiredLibraryTypeResolver<TParent = any> {
+    name?: ArticleRequiredLibraryToNameResolver<TParent>;
+    url?: ArticleRequiredLibraryToUrlResolver<TParent>;
+    mediaType?: ArticleRequiredLibraryToMediaTypeResolver<TParent>;
+  }
+  
+  export interface ArticleRequiredLibraryToNameResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleRequiredLibraryToUrlResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleRequiredLibraryToMediaTypeResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLArticleMetaDataTypeResolver<TParent = any> {
+    footnotes?: ArticleMetaDataToFootnotesResolver<TParent>;
+    images?: ArticleMetaDataToImagesResolver<TParent>;
+    audios?: ArticleMetaDataToAudiosResolver<TParent>;
+    brightcoves?: ArticleMetaDataToBrightcovesResolver<TParent>;
+    h5ps?: ArticleMetaDataToH5psResolver<TParent>;
+    concepts?: ArticleMetaDataToConceptsResolver<TParent>;
+    copyText?: ArticleMetaDataToCopyTextResolver<TParent>;
+  }
+  
+  export interface ArticleMetaDataToFootnotesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToImagesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToAudiosResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToBrightcovesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToH5psResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToConceptsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleMetaDataToCopyTextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLFootNoteTypeResolver<TParent = any> {
+    ref?: FootNoteToRefResolver<TParent>;
+    title?: FootNoteToTitleResolver<TParent>;
+    year?: FootNoteToYearResolver<TParent>;
+    authors?: FootNoteToAuthorsResolver<TParent>;
+    edition?: FootNoteToEditionResolver<TParent>;
+    publisher?: FootNoteToPublisherResolver<TParent>;
+    url?: FootNoteToUrlResolver<TParent>;
+  }
+  
+  export interface FootNoteToRefResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToTitleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToYearResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToAuthorsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToEditionResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToPublisherResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface FootNoteToUrlResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -3049,122 +3170,6 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLVisualElementTypeResolver<TParent = any> {
-    resource?: VisualElementToResourceResolver<TParent>;
-    resourceId?: VisualElementToResourceIdResolver<TParent>;
-    title?: VisualElementToTitleResolver<TParent>;
-    url?: VisualElementToUrlResolver<TParent>;
-    alt?: VisualElementToAltResolver<TParent>;
-    account?: VisualElementToAccountResolver<TParent>;
-    player?: VisualElementToPlayerResolver<TParent>;
-    videoid?: VisualElementToVideoidResolver<TParent>;
-    thumbnail?: VisualElementToThumbnailResolver<TParent>;
-    image?: VisualElementToImageResolver<TParent>;
-    oembed?: VisualElementToOembedResolver<TParent>;
-    lowerRightX?: VisualElementToLowerRightXResolver<TParent>;
-    lowerRightY?: VisualElementToLowerRightYResolver<TParent>;
-    upperLeftX?: VisualElementToUpperLeftXResolver<TParent>;
-    upperLeftY?: VisualElementToUpperLeftYResolver<TParent>;
-    focalX?: VisualElementToFocalXResolver<TParent>;
-    focalY?: VisualElementToFocalYResolver<TParent>;
-    copyright?: VisualElementToCopyrightResolver<TParent>;
-    copyText?: VisualElementToCopyTextResolver<TParent>;
-  }
-  
-  export interface VisualElementToResourceResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToResourceIdResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToTitleResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToUrlResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToAltResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToAccountResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToPlayerResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToVideoidResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToThumbnailResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToImageResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToOembedResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToLowerRightXResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToLowerRightYResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToUpperLeftXResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToUpperLeftYResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToFocalXResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToFocalYResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToCopyrightResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementToCopyTextResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface GQLVisualElementOembedTypeResolver<TParent = any> {
-    title?: VisualElementOembedToTitleResolver<TParent>;
-    html?: VisualElementOembedToHtmlResolver<TParent>;
-    fullscreen?: VisualElementOembedToFullscreenResolver<TParent>;
-  }
-  
-  export interface VisualElementOembedToTitleResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementOembedToHtmlResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface VisualElementOembedToFullscreenResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
   export interface GQLFrontpageSearchTypeResolver<TParent = any> {
     topicResources?: FrontpageSearchToTopicResourcesResolver<TParent>;
     learningResources?: FrontpageSearchToLearningResourcesResolver<TParent>;
@@ -3397,6 +3402,14 @@ declare global {
   }
   
   export interface AudioSearchToResultsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLembedVisualelementTypeResolver<TParent = any> {
+    visualElement?: embedVisualelementToVisualElementResolver<TParent>;
+  }
+  
+  export interface embedVisualelementToVisualElementResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -23,20 +23,20 @@ declare global {
     filmfrontpage?: GQLFilmFrontpage;
     learningpath?: GQLLearningpath;
     learningpathStep?: GQLLearningpathStep;
-    subjects?: Array<GQLSubject | null>;
+    subjects?: Array<GQLSubject>;
     topic?: GQLTopic;
-    topics?: Array<GQLTopic | null>;
+    topics?: Array<GQLTopic>;
     frontpage?: GQLFrontpage;
-    filters?: Array<GQLSubjectFilter | null>;
-    competenceGoals?: Array<GQLCompetenceGoal | null>;
+    filters?: Array<GQLSubjectFilter>;
+    competenceGoals?: Array<GQLCompetenceGoal>;
     competenceGoal?: GQLCompetenceGoal;
-    coreElements?: Array<GQLCoreElement | null>;
+    coreElements?: Array<GQLCoreElement>;
     coreElement?: GQLCoreElement;
     search?: GQLSearch;
-    resourceTypes?: Array<GQLResourceTypeDefinition | null>;
-    groupSearch?: Array<GQLGroupSearch | null>;
+    resourceTypes?: Array<GQLResourceTypeDefinition>;
+    groupSearch?: Array<GQLGroupSearch>;
     listingPage?: GQLListingPage;
-    concepts?: Array<GQLConcept | null>;
+    concepts?: Array<GQLConcept>;
     detailedConcept?: GQLDetailedConcept;
     conceptSearch?: GQLConceptResult;
     frontpageSearch?: GQLFrontpageSearch;
@@ -50,17 +50,17 @@ declare global {
     name: string;
     contentUri?: string;
     path?: string;
-    paths?: Array<string | null>;
+    paths?: Array<string>;
     meta?: GQLMeta;
     metadata?: GQLTaxonomyMetadata;
     article?: GQLArticle;
     learningpath?: GQLLearningpath;
-    filters?: Array<GQLFilter | null>;
+    filters?: Array<GQLFilter>;
     rank?: number;
     relevanceId?: string;
-    resourceTypes?: Array<GQLResourceType | null>;
-    parentTopics?: Array<GQLTopic | null>;
-    breadcrumbs?: Array<Array<string | null> | null>;
+    resourceTypes?: Array<GQLResourceType>;
+    parentTopics?: Array<GQLTopic>;
+    breadcrumbs?: Array<Array<string>>;
   }
   
   export interface GQLTaxonomyEntity {
@@ -68,11 +68,11 @@ declare global {
     name: string;
     contentUri?: string;
     path?: string;
-    paths?: Array<string | null>;
+    paths?: Array<string>;
     meta?: GQLMeta;
     metadata?: GQLTaxonomyMetadata;
     article?: GQLArticle;
-    filters?: Array<GQLFilter | null>;
+    filters?: Array<GQLFilter>;
     relevanceId?: string;
     rank?: number;
   }
@@ -101,7 +101,7 @@ declare global {
   }
   
   export interface GQLTaxonomyMetadata {
-    grepCodes?: Array<string | null>;
+    grepCodes?: Array<string>;
     visible?: boolean;
     customFields?: GQLJSON;
   }
@@ -122,18 +122,18 @@ declare global {
     metaDescription: string;
     articleType: string;
     oldNdlaUrl?: string;
-    requiredLibraries?: Array<GQLArticleRequiredLibrary | null>;
+    requiredLibraries?: Array<GQLArticleRequiredLibrary>;
     metaData?: GQLArticleMetaData;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     copyright: GQLCopyright;
-    tags?: Array<string | null>;
-    grepCodes?: Array<string | null>;
-    competenceGoals?: Array<GQLCompetenceGoal | null>;
-    coreElements?: Array<GQLCoreElement | null>;
-    crossSubjectTopics?: Array<GQLCrossSubjectElement | null>;
+    tags?: Array<string>;
+    grepCodes?: Array<string>;
+    competenceGoals?: Array<GQLCompetenceGoal>;
+    coreElements?: Array<GQLCoreElement>;
+    crossSubjectTopics?: Array<GQLCrossSubjectElement>;
     oembed?: string;
-    conceptIds?: Array<string | null>;
-    concepts?: Array<GQLConcept | null>;
+    conceptIds?: Array<string>;
+    concepts?: Array<GQLConcept>;
   }
   
   export interface GQLVisualElement {
@@ -156,6 +156,8 @@ declare global {
     focalY?: number;
     copyright?: GQLCopyright;
     copyText?: string;
+    embed?: string;
+    language?: string;
   }
   
   export interface GQLImageLicense {
@@ -169,9 +171,9 @@ declare global {
   
   export interface GQLCopyright {
     license?: GQLLicense;
-    creators?: Array<GQLContributor | null>;
-    processors?: Array<GQLContributor | null>;
-    rightsholders?: Array<GQLContributor | null>;
+    creators?: Array<GQLContributor>;
+    processors?: Array<GQLContributor>;
+    rightsholders?: Array<GQLContributor>;
     origin?: string;
   }
   
@@ -199,12 +201,12 @@ declare global {
   }
   
   export interface GQLArticleMetaData {
-    footnotes?: Array<GQLFootNote | null>;
-    images?: Array<GQLImageLicense | null>;
-    audios?: Array<GQLAudioLicense | null>;
-    brightcoves?: Array<GQLBrightcoveLicense | null>;
-    h5ps?: Array<GQLH5pLicense | null>;
-    concepts?: Array<GQLConceptLicense | null>;
+    footnotes?: Array<GQLFootNote>;
+    images?: Array<GQLImageLicense>;
+    audios?: Array<GQLAudioLicense>;
+    brightcoves?: Array<GQLBrightcoveLicense>;
+    h5ps?: Array<GQLH5pLicense>;
+    concepts?: Array<GQLConceptLicense>;
     copyText?: string;
   }
   
@@ -212,7 +214,7 @@ declare global {
     ref: number;
     title: string;
     year: string;
-    authors: Array<string | null>;
+    authors: Array<string>;
     edition?: string;
     publisher?: string;
     url?: string;
@@ -269,10 +271,10 @@ declare global {
     curriculum?: GQLReference;
     competenceGoalSetCode?: string;
     competenceGoalSet?: GQLReference;
-    crossSubjectTopicsCodes?: Array<GQLElement | null>;
-    crossSubjectTopics?: Array<GQLElement | null>;
-    coreElementsCodes?: Array<GQLElement | null>;
-    coreElements?: Array<GQLElement | null>;
+    crossSubjectTopicsCodes?: Array<GQLElement>;
+    crossSubjectTopics?: Array<GQLElement>;
+    coreElementsCodes?: Array<GQLElement>;
+    coreElements?: Array<GQLElement>;
   }
   
   export interface GQLReference {
@@ -305,7 +307,7 @@ declare global {
     id?: number;
     title?: string;
     content?: string;
-    tags?: Array<string | null>;
+    tags?: Array<string>;
     metaImage?: GQLMetaImage;
   }
   
@@ -327,10 +329,10 @@ declare global {
     canEdit?: boolean;
     verificationStatus?: string;
     lastUpdated?: string;
-    tags?: Array<string | null>;
-    supportedLanguages?: Array<string | null>;
+    tags?: Array<string>;
+    supportedLanguages?: Array<string>;
     isBasedOn?: number;
-    learningsteps?: Array<GQLLearningpathStep | null>;
+    learningsteps?: Array<GQLLearningpathStep>;
     metaUrl?: string;
     revision?: number;
     learningstepUrl?: string;
@@ -340,7 +342,7 @@ declare global {
   
   export interface GQLLearningpathCopyright {
     license?: GQLLicense;
-    contributors?: Array<GQLContributor | null>;
+    contributors?: Array<GQLContributor>;
   }
   
   export interface GQLLearningpathStep {
@@ -353,7 +355,7 @@ declare global {
     metaUrl?: string;
     revision?: number;
     status?: string;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     type?: string;
     article?: GQLArticle;
     resource?: GQLResource;
@@ -382,7 +384,7 @@ declare global {
   export interface GQLResourceType {
     id: string;
     name: string;
-    resources?: Array<GQLResource | null>;
+    resources?: Array<GQLResource>;
   }
   
   export interface GQLTopic extends GQLTaxonomyEntity {
@@ -390,21 +392,21 @@ declare global {
     name: string;
     contentUri?: string;
     path?: string;
-    paths?: Array<string | null>;
+    paths?: Array<string>;
     meta?: GQLMeta;
     metadata?: GQLTaxonomyMetadata;
     article?: GQLArticle;
-    filters?: Array<GQLFilter | null>;
+    filters?: Array<GQLFilter>;
     rank?: number;
     relevanceId?: string;
     isPrimary?: boolean;
     parent?: string;
-    subtopics?: Array<GQLTopic | null>;
-    pathTopics?: Array<Array<GQLTopic | null> | null>;
-    coreResources?: Array<GQLResource | null>;
-    supplementaryResources?: Array<GQLResource | null>;
-    alternateTopics?: Array<GQLTopic | null>;
-    breadcrumbs?: Array<Array<string | null> | null>;
+    subtopics?: Array<GQLTopic>;
+    pathTopics?: Array<Array<GQLTopic>>;
+    coreResources?: Array<GQLResource>;
+    supplementaryResources?: Array<GQLResource>;
+    alternateTopics?: Array<GQLTopic>;
+    breadcrumbs?: Array<Array<string>>;
   }
   
   export interface GQLSubject {
@@ -413,8 +415,8 @@ declare global {
     name: string;
     path: string;
     metadata?: GQLTaxonomyMetadata;
-    filters?: Array<GQLSubjectFilter | null>;
-    frontpageFilters?: Array<GQLSubjectFilter | null>;
+    filters?: Array<GQLSubjectFilter>;
+    frontpageFilters?: Array<GQLSubjectFilter>;
     subjectpage?: GQLSubjectPage;
     topics?: Array<GQLTopic>;
   }
@@ -430,15 +432,15 @@ declare global {
   
   export interface GQLSubjectPage {
     topical?: GQLTaxonomyEntity;
-    mostRead?: Array<GQLTaxonomyEntity | null>;
+    mostRead?: Array<GQLTaxonomyEntity>;
     banner?: GQLSubjectPageBanner;
     id: number;
     name?: string;
     facebook?: string;
-    editorsChoices?: Array<GQLTaxonomyEntity | null>;
-    latestContent?: Array<GQLTaxonomyEntity | null>;
+    editorsChoices?: Array<GQLTaxonomyEntity>;
+    latestContent?: Array<GQLTaxonomyEntity>;
     about?: GQLSubjectPageAbout;
-    goTo?: Array<GQLResourceTypeDefinition | null>;
+    goTo?: Array<GQLResourceTypeDefinition>;
     metaDescription?: string;
     layout?: string;
     twitter?: string;
@@ -466,14 +468,14 @@ declare global {
   export interface GQLResourceTypeDefinition {
     id: string;
     name: string;
-    subtypes?: Array<GQLResourceTypeDefinition | null>;
+    subtypes?: Array<GQLResourceTypeDefinition>;
   }
   
   export interface GQLFilmFrontpage {
     name?: string;
-    about?: Array<GQLFilmPageAbout | null>;
-    movieThemes?: Array<GQLMovieTheme | null>;
-    slideShow?: Array<GQLMovie | null>;
+    about?: Array<GQLFilmPageAbout>;
+    movieThemes?: Array<GQLMovieTheme>;
+    slideShow?: Array<GQLMovie>;
   }
   
   export interface GQLFilmPageAbout {
@@ -484,8 +486,8 @@ declare global {
   }
   
   export interface GQLMovieTheme {
-    name?: Array<GQLName | null>;
-    movies?: Array<GQLMovie | null>;
+    name?: Array<GQLName>;
+    movies?: Array<GQLMovie>;
   }
   
   export interface GQLName {
@@ -498,13 +500,13 @@ declare global {
     title?: string;
     metaImage?: GQLMetaImage;
     metaDescription?: string;
-    resourceTypes?: Array<GQLResourceType | null>;
+    resourceTypes?: Array<GQLResourceType>;
     path?: string;
   }
   
   export interface GQLFrontpage {
-    topical?: Array<GQLResource | null>;
-    categories?: Array<GQLCategory | null>;
+    topical?: Array<GQLResource>;
+    categories?: Array<GQLCategory>;
   }
   
   export interface GQLCategory {
@@ -517,22 +519,22 @@ declare global {
     page?: number;
     language?: string;
     totalCount?: number;
-    results?: Array<GQLSearchResult | null>;
-    suggestions?: Array<GQLSuggestionResult | null>;
-    aggregations?: Array<GQLAggregationResult | null>;
+    results?: Array<GQLSearchResult>;
+    suggestions?: Array<GQLSuggestionResult>;
+    aggregations?: Array<GQLAggregationResult>;
     concepts?: GQLConceptResult;
   }
   
   export interface GQLSearchResult {
     id: number;
     title?: string;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     url?: string;
     metaDescription?: string;
     metaImage?: GQLMetaImage;
     contentType?: string;
-    traits?: Array<string | null>;
-    contexts?: Array<GQLSearchContext | null>;
+    traits?: Array<string>;
+    contexts?: Array<GQLSearchContext>;
   }
   
   /** Use this to resolve interface type SearchResult */
@@ -547,16 +549,16 @@ declare global {
   }
   
   export interface GQLSearchContext {
-    breadcrumbs?: Array<string | null>;
+    breadcrumbs?: Array<string>;
     learningResourceType?: string;
-    resourceTypes?: Array<GQLSearchContextResourceTypes | null>;
+    resourceTypes?: Array<GQLSearchContextResourceTypes>;
     subject?: string;
     subjectId?: string;
     relevance?: string;
     path?: string;
     id?: string;
     language?: string;
-    filters?: Array<GQLSearchContextFilter | null>;
+    filters?: Array<GQLSearchContextFilter>;
   }
   
   export interface GQLSearchContextResourceTypes {
@@ -573,14 +575,14 @@ declare global {
   
   export interface GQLSuggestionResult {
     name?: string;
-    suggestions?: Array<GQLSearchSuggestion | null>;
+    suggestions?: Array<GQLSearchSuggestion>;
   }
   
   export interface GQLSearchSuggestion {
     text?: string;
     offset?: number;
     length?: number;
-    options?: Array<GQLSuggestOption | null>;
+    options?: Array<GQLSuggestOption>;
   }
   
   export interface GQLSuggestOption {
@@ -592,7 +594,7 @@ declare global {
     field?: string;
     sumOtherDocCount?: number;
     docCountErrorUpperBound?: number;
-    values?: Array<GQLBucketResult | null>;
+    values?: Array<GQLBucketResult>;
   }
   
   export interface GQLBucketResult {
@@ -602,15 +604,15 @@ declare global {
   
   export interface GQLConceptResult {
     totalCount?: number;
-    concepts?: Array<GQLConcept | null>;
+    concepts?: Array<GQLConcept>;
   }
   
   export interface GQLGroupSearch {
     language?: string;
     resourceType?: string;
-    resources?: Array<GQLGroupSearchResult | null>;
-    suggestions?: Array<GQLSuggestionResult | null>;
-    aggregations?: Array<GQLAggregationResult | null>;
+    resources?: Array<GQLGroupSearchResult>;
+    suggestions?: Array<GQLSuggestionResult>;
+    aggregations?: Array<GQLAggregationResult>;
     totalCount?: number;
   }
   
@@ -619,14 +621,14 @@ declare global {
     path: string;
     name: string;
     ingress?: string;
-    traits?: Array<string | null>;
-    contexts?: Array<GQLSearchContext | null>;
+    traits?: Array<string>;
+    contexts?: Array<GQLSearchContext>;
     metaImage?: GQLMetaImage;
   }
   
   export interface GQLListingPage {
-    subjects?: Array<GQLSubject | null>;
-    tags?: Array<string | null>;
+    subjects?: Array<GQLSubject>;
+    tags?: Array<string>;
   }
   
   export interface GQLDetailedConcept {
@@ -634,11 +636,11 @@ declare global {
     title?: string;
     content?: string;
     created?: string;
-    tags?: Array<string | null>;
+    tags?: Array<string>;
     image?: GQLImageLicense;
-    subjectIds?: Array<string | null>;
-    articleIds?: Array<string | null>;
-    articles?: Array<GQLMeta | null>;
+    subjectIds?: Array<string>;
+    articleIds?: Array<string>;
+    articles?: Array<GQLMeta>;
     visualElement?: GQLVisualElement;
     copyright?: GQLCopyright;
   }
@@ -649,18 +651,18 @@ declare global {
   }
   
   export interface GQLFrontPageResources {
-    results?: Array<GQLFrontpageSearchResult | null>;
+    results?: Array<GQLFrontpageSearchResult>;
     totalCount?: number;
-    suggestions?: Array<GQLSuggestionResult | null>;
+    suggestions?: Array<GQLSuggestionResult>;
   }
   
   export interface GQLFrontpageSearchResult {
     id: string;
     name?: string;
-    resourceTypes?: Array<GQLSearchContextResourceTypes | null>;
+    resourceTypes?: Array<GQLSearchContextResourceTypes>;
     subject?: string;
     path?: string;
-    filters?: Array<GQLSearchContextFilter | null>;
+    filters?: Array<GQLSearchContextFilter>;
   }
   
   export interface GQLAudio {
@@ -670,7 +672,7 @@ declare global {
     audioFile: GQLAudioFile;
     copyright: GQLCopyright;
     tags?: GQLTags;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     audioType: string;
     podcastMeta?: GQLPodcastMeta;
   }
@@ -688,7 +690,7 @@ declare global {
   }
   
   export interface GQLTags {
-    tags?: Array<string | null>;
+    tags?: Array<string>;
     language: string;
   }
   
@@ -711,7 +713,7 @@ declare global {
     page?: number;
     language?: string;
     totalCount?: number;
-    results?: Array<GQLAudio | null>;
+    results?: Array<GQLAudio>;
   }
   
   export interface GQLembedVisualelement {
@@ -726,35 +728,35 @@ declare global {
   
   export interface GQLMoviePath {
     path?: string;
-    paths?: Array<string | null>;
+    paths?: Array<string>;
   }
   
   export interface GQLMovieResourceTypes {
-    resourceTypes?: Array<GQLResourceType | null>;
+    resourceTypes?: Array<GQLResourceType>;
   }
   
   export interface GQLArticleSearchResult extends GQLSearchResult {
     id: number;
     title?: string;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     url?: string;
     metaDescription?: string;
     metaImage?: GQLMetaImage;
     contentType?: string;
-    traits?: Array<string | null>;
-    contexts?: Array<GQLSearchContext | null>;
+    traits?: Array<string>;
+    contexts?: Array<GQLSearchContext>;
   }
   
   export interface GQLLearningpathSearchResult extends GQLSearchResult {
     id: number;
     title?: string;
-    supportedLanguages?: Array<string | null>;
+    supportedLanguages?: Array<string>;
     url?: string;
     metaDescription?: string;
     metaImage?: GQLMetaImage;
     contentType?: string;
-    traits?: Array<string | null>;
-    contexts?: Array<GQLSearchContext | null>;
+    traits?: Array<string>;
+    contexts?: Array<GQLSearchContext>;
   }
   
   /*********************************
@@ -968,7 +970,7 @@ declare global {
   }
   
   export interface QueryToCompetenceGoalsArgs {
-    codes?: Array<string | null>;
+    codes?: Array<string>;
     nodeId?: string;
     language?: string;
   }
@@ -985,7 +987,7 @@ declare global {
   }
   
   export interface QueryToCoreElementsArgs {
-    codes?: Array<string | null>;
+    codes?: Array<string>;
     language?: string;
   }
   export interface QueryToCoreElementsResolver<TParent = any, TResult = any> {
@@ -1016,7 +1018,7 @@ declare global {
     languageFilter?: string;
     relevance?: string;
     grepCodes?: string;
-    aggregatePaths?: Array<string | null>;
+    aggregatePaths?: Array<string>;
   }
   export interface QueryToSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -1037,7 +1039,7 @@ declare global {
     language?: string;
     fallback?: string;
     grepCodes?: string;
-    aggregatePaths?: Array<string | null>;
+    aggregatePaths?: Array<string>;
   }
   export interface QueryToGroupSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToGroupSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -1048,7 +1050,7 @@ declare global {
   }
   
   export interface QueryToConceptsArgs {
-    ids?: Array<string | null>;
+    ids?: Array<string>;
   }
   export interface QueryToConceptsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToConceptsArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -1417,6 +1419,8 @@ declare global {
     focalY?: VisualElementToFocalYResolver<TParent>;
     copyright?: VisualElementToCopyrightResolver<TParent>;
     copyText?: VisualElementToCopyTextResolver<TParent>;
+    embed?: VisualElementToEmbedResolver<TParent>;
+    language?: VisualElementToLanguageResolver<TParent>;
   }
   
   export interface VisualElementToResourceResolver<TParent = any, TResult = any> {
@@ -1492,6 +1496,14 @@ declare global {
   }
   
   export interface VisualElementToCopyTextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToEmbedResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface VisualElementToLanguageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -970,7 +970,7 @@ declare global {
   }
   
   export interface QueryToCompetenceGoalsArgs {
-    codes?: Array<string>;
+    codes?: Array<string | null>;
     nodeId?: string;
     language?: string;
   }
@@ -987,7 +987,7 @@ declare global {
   }
   
   export interface QueryToCoreElementsArgs {
-    codes?: Array<string>;
+    codes?: Array<string | null>;
     language?: string;
   }
   export interface QueryToCoreElementsResolver<TParent = any, TResult = any> {
@@ -1018,7 +1018,7 @@ declare global {
     languageFilter?: string;
     relevance?: string;
     grepCodes?: string;
-    aggregatePaths?: Array<string>;
+    aggregatePaths?: Array<string | null>;
   }
   export interface QueryToSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -1039,7 +1039,7 @@ declare global {
     language?: string;
     fallback?: string;
     grepCodes?: string;
-    aggregatePaths?: Array<string>;
+    aggregatePaths?: Array<string | null>;
   }
   export interface QueryToGroupSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToGroupSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -62,7 +62,6 @@ export async function resolveJson(response: Response): Promise<any> {
   }
 
   const json = await response.json();
-
   if (ok) {
     return externalsToH5pMetaData(json);
   }

--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2021-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+import { localConverter } from '../config';
+import { fetch, resolveJson } from './apiHelpers';
+
+export async function fetchImage(imageId: string, context: Context) {
+  const imageResponse = await fetch(`/image-api/v2/images/${imageId}`, context);
+  const image = await resolveJson(imageResponse);
+  return {
+    title: image.title.title,
+    src: image.imageUrl,
+    altText: image.alttext.alttext,
+    contentType: image.contentType,
+    copyright: image.copyright,
+  };
+}
+
+export async function fetchVisualElementLicense(
+  visualElement: string,
+  resource: string,
+  context: Context,
+): Promise<GQLBrightcoveLicense | GQLH5pLicense> {
+  const host = localConverter ? 'http://localhost:3100' : '';
+  const metaDataResponse = await fetch(
+    encodeURI(
+      `${host}/article-converter/json/${context.language}/meta-data?embed=${visualElement}`,
+    ),
+    context,
+  );
+  const metaData = await resolveJson(metaDataResponse);
+  return metaData.metaData[resource][0];
+}
+
+export async function fetchOembed(
+  url: string,
+  context: Context,
+): Promise<GQLLearningpathStepOembed> {
+  const response = await fetch(`/oembed-proxy/v1/oembed?url=${url}`, context);
+  return resolveJson(response);
+}


### PR DESCRIPTION
er med å fikser NDLANO/Issues#2583

VisualElementet som var tilgjengelig på article ved fetch var ikke typet riktig. Det kom som et objekt av `visualElement: {language, visualElement}` men var typet til string. Det breaket queryen om man spurte etter visualElementet i article queryen. Tok så å gjorde som i concept-api for å kunne displaye visualElementet som ønsket i verktøykassa.

Forandret array typene til non-nullable, så ingen arrays kunne inneholde null objekter. Med å ha `!` bak objektet i arrayet så vil du fortsatt kunne returnere tomme arrayer men ikke arrayer med null. Fant ingen steder i de ulike apiene hvor null ble returnert eller i article-converter. 

- Forandret schema typene til å ikke kunne inneholde null typer i arrays
- Behandlet visualelement som i concept-api