### PR TITLE
Handle missing visualelement iframe which does not have license.

### DIFF
--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -93,10 +93,12 @@ export async function parseVisualElement(
         caption: data.caption,
       };
       visualElement.url = data.url;
+    } else {
+      visualElement.url = data.url;
     }
 
-    visualElement.copyright = license.copyright;
-    visualElement.title = license.title;
+    visualElement.copyright = license?.copyright;
+    visualElement.title = license?.title;
   } else {
     const visualElementOembed = await fetchOembed(data.url, context);
     visualElement.url = data.url;


### PR DESCRIPTION
Emnet https://test.ndla.no/subject:d1fe9d0a-a54d-49db-a4c2-fd5463a7c9e7/topic:3cdf9349-4593-498c-a899-9310133a4788/topic:45530d1b-134c-4fb4-94a0-7e26d118fa9c/topic:8c5a85e1-048d-4acb-922e-f64430de3f48/ har visuet element iframe, noko som ikkje håndteres i dag. Legger på ekstra håndtering for å fikse det.