### PR TITLE
Bruker topicid for å plukke korrekt path for ressurs

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -21,7 +21,7 @@ interface FetchTopicResourcesParams {
 }
 
 export async function fetchResource(
-  { id, subjectId }: QueryToResourceArgs,
+  { id, subjectId, topicId }: QueryToResourceArgs,
   context: Context,
 ): Promise<GQLResource> {
   const response = await fetch(
@@ -42,7 +42,7 @@ export async function fetchResource(
   let path = paths[0];
 
   if (subjectId) {
-    const primaryPath = findPrimaryPath(paths, subjectId);
+    const primaryPath = findPrimaryPath(paths, subjectId, topicId);
     path = primaryPath ? primaryPath : path;
   }
   return { ...resource, path, paths };
@@ -112,22 +112,12 @@ export async function fetchTopics(
   return resolveJson(response);
 }
 
-export async function fetchTopic(
-  params: { id: string; subjectId?: string },
-  context: Context,
-) {
+export async function fetchTopic(params: { id: string }, context: Context) {
   const response = await fetch(
     `/${context.taxonomyUrl}/v1/topics/${params.id}?language=${context.language}`,
     context,
   );
-  const topic: GQLTaxonomyEntity = await resolveJson(response);
-
-  if (params.subjectId) {
-    const primaryPath = findPrimaryPath(topic.paths, params.subjectId);
-    const path = primaryPath ? primaryPath : topic.path;
-    return { ...topic, path };
-  }
-  return topic;
+  return await resolveJson(response);
 }
 
 export async function fetchSubtopics(
@@ -170,7 +160,7 @@ export async function fetchTopicResources(
   const resources: GQLTaxonomyEntity[] = await resolveJson(response);
   resources.forEach(resource => {
     if (subjectId) {
-      const primaryPath = findPrimaryPath(resource.paths, subjectId);
+      const primaryPath = findPrimaryPath(resource.paths, subjectId, topic.id);
       const path = primaryPath ? primaryPath : resource.path;
       resource.path = path;
     }

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -25,10 +25,10 @@ import { ndlaUrl } from '../config';
 export const Query = {
   async resource(
     _: any,
-    { id, subjectId }: QueryToResourceArgs,
+    { id, subjectId, topicId }: QueryToResourceArgs,
     context: Context,
   ): Promise<GQLResource> {
-    return fetchResource({ id, subjectId }, context);
+    return fetchResource({ id, subjectId, topicId }, context);
   },
   async resourceTypes(
     _: any,

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -33,10 +33,10 @@ interface TopicResponse {
 export const Query = {
   async topic(
     _: any,
-    { id, subjectId }: QueryToTopicArgs,
+    { id }: QueryToTopicArgs,
     context: Context,
   ): Promise<GQLTopic> {
-    return fetchTopic({ id, subjectId }, context);
+    return fetchTopic({ id }, context);
   },
   async topics(
     _: any,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -740,7 +740,7 @@ export const typeDefs = gql`
   }
 
   type Query {
-    resource(id: String!, subjectId: String): Resource
+    resource(id: String!, subjectId: String, topicId: String): Resource
     article(
       id: String!
       filterIds: String

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -3483,6 +3483,7 @@ declare global {
   export interface QueryToResourceArgs {
     id: string;
     subjectId?: string;
+    topicId?: string;
   }
   export interface QueryToResourceResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToResourceArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/utils/__tests__/articleHelper-test.ts
+++ b/src/utils/__tests__/articleHelper-test.ts
@@ -58,14 +58,18 @@ test('getLearningpathIdFromUrn urn:learningpath:1 is 1', async () => {
   expect(getLearningpathIdFromUrn('urn:learningpath:1')).toBe('1');
 });
 
-test('findPrimaryPath returns correct path for subject, or undefined', () => {
+test('findPrimaryPath for resources returns correct path for subject, or undefined', () => {
   const path1 = '/subject:1/topic:1/resource:1';
   const path2 = '/subject:2/topic:2/resource:2';
   const path3 = '/subject:3/topic:3/resource:3';
-  const paths = [path1, path2, path3];
+  const path4 = '/subject:3/topic:4/resource:3';
+  const path5 = '/subject:3/topic:4/topic:5/resource:3';
+  const paths = [path1, path2, path3, path4, path5];
   expect(findPrimaryPath(paths, 'urn:subject:1')).toBe(path1);
   expect(findPrimaryPath(paths, 'urn:subject:2')).toBe(path2);
   expect(findPrimaryPath(paths, 'urn:subject:3')).toBe(path3);
+  expect(findPrimaryPath(paths, 'urn:subject:3', 'urn:topic:4')).toBe(path4);
+  expect(findPrimaryPath(paths, 'urn:subject:3', 'urn:topic:5')).toBe(path5);
   expect(findPrimaryPath(paths, 'urn:subject:4')).toBe(undefined);
   expect(findPrimaryPath([], 'urn:subject:1')).toBe(undefined);
 });

--- a/src/utils/articleHelpers.ts
+++ b/src/utils/articleHelpers.ts
@@ -23,8 +23,11 @@ export function stripUrn(str: string): string {
 export function findPrimaryPath(
   paths: string[],
   subjectId: string,
+  topicId?: string,
 ): string | undefined {
-  return paths.find(path => path.split('/')[1] === stripUrn(subjectId));
+  return paths
+    .filter(path => path.startsWith(`/${stripUrn(subjectId)}/`))
+    .find(path => path.includes(`/${stripUrn(topicId || '')}`));
 }
 
 export async function filterMissingArticles(


### PR DESCRIPTION
Add topicid as possible param for resource.
Ignore subjectid when fetching topic.

Fixes NDLANO/Issues#2741

Plukker korrekt path for ressurser tilhørende et emne. Legger på ekstra param for resource for å bruke ny funksjonalitet. Ignorerer subjectid param for topic fordi det ikkje lenger gir meining.