### PR TITLE
Adds availability from article-api to taxonomy-element

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -157,6 +157,7 @@ export async function fetchArticles(
         metaDescription: article.metaDescription?.metaDescription,
         lastUpdated: article.lastUpdated,
         metaImage: article.metaImage,
+        availability: article.availability,
       };
     }
     return null;

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -28,8 +28,7 @@ export async function fetchResource(
     `/${context.taxonomyUrl}/v1/resources/${id}/full?language=${context.language}`,
     context,
   );
-  const resource: GQLTaxonomyEntity = await resolveJson(response);
-
+  const resource: GQLResource = await resolveJson(response);
   // TODO: Replace parent-filtering with changes in taxonomy
   const data = await context.loaders.subjectsLoader.load('all');
   const paths = resource.paths?.filter(p => {
@@ -53,7 +52,14 @@ export async function fetchResource(
     );
     availability = article.availability;
   }
-  return { ...resource, path, paths, availability };
+
+  let relevanceId = undefined;
+  if (topicId) {
+    const parent = resource.parentTopics.find(topic => topic.id === topicId);
+    relevanceId = parent?.relevanceId || 'urn:relevance:core';
+  }
+
+  return { ...resource, path, paths, availability, relevanceId };
 }
 
 export async function fetchFilters(

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -53,7 +53,7 @@ export async function fetchResource(
     availability = article.availability;
   }
 
-  let relevanceId = undefined;
+  let relevanceId;
   if (topicId) {
     const parent = resource.parentTopics.find(topic => topic.id === topicId);
     relevanceId = parent?.relevanceId || 'urn:relevance:core';

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -21,7 +21,7 @@ import {
 } from './api';
 import { FrontpageResponse } from './api/frontpageApi';
 
-export function articlesLoader(context: Context): DataLoader<string, any> {
+export function articlesLoader(context: Context): DataLoader<string, GQLMeta> {
   return new DataLoader(
     async articleIds => {
       return fetchArticles(articleIds, context);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -87,6 +87,7 @@ export const typeDefs = gql`
     metaDescription: String
     metaImage: MetaImage
     lastUpdated: String
+    availability: String
   }
 
   type LearningpathStepEmbedUrl {
@@ -168,6 +169,7 @@ export const typeDefs = gql`
     filters: [Filter!]
     relevanceId: String
     rank: Int
+    availability: String
   }
 
   type Resource implements TaxonomyEntity {
@@ -182,6 +184,7 @@ export const typeDefs = gql`
     learningpath: Learningpath
     filters: [Filter!]
     rank: Int
+    availability: String
     relevanceId: String
     resourceTypes: [ResourceType!]
     parentTopics: [Topic!]
@@ -199,6 +202,7 @@ export const typeDefs = gql`
     article(filterIds: String, subjectId: String): Article
     filters: [Filter!]
     rank: Int
+    availability: String
     relevanceId: String
     isPrimary: Boolean
     parent: String
@@ -339,6 +343,7 @@ export const typeDefs = gql`
     conceptIds: [String!]
     concepts: [DetailedConcept!]
     relatedContent: [RelatedContent!]
+    availability: String
   }
 
   type embedVisualelement {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -15,7 +15,7 @@ declare global {
     shouldUseCache: boolean;
     taxonomyUrl: string;
     loaders?: {
-      articlesLoader?: DataLoader<string, any>;
+      articlesLoader?: DataLoader<string, GQLMeta>;
       learningpathsLoader?: DataLoader<string, any>;
       filterLoader?: DataLoader<string, GQLSubjectFilter[]>;
       subjectTopicsLoader?: DataLoader<

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -92,6 +92,7 @@ declare global {
     metaDescription?: string;
     metaImage?: GQLMetaImage;
     lastUpdated?: string;
+    availability?: string;
   }
   
   export interface GQLLearningpathStepEmbedUrl {
@@ -173,6 +174,7 @@ declare global {
     filters?: Array<GQLFilter>;
     relevanceId?: string;
     rank?: number;
+    availability?: string;
   }
   
   /** Use this to resolve interface type TaxonomyEntity */
@@ -196,6 +198,7 @@ declare global {
     learningpath?: GQLLearningpath;
     filters?: Array<GQLFilter>;
     rank?: number;
+    availability?: string;
     relevanceId?: string;
     resourceTypes?: Array<GQLResourceType>;
     parentTopics?: Array<GQLTopic>;
@@ -213,6 +216,7 @@ declare global {
     article?: GQLArticle;
     filters?: Array<GQLFilter>;
     rank?: number;
+    availability?: string;
     relevanceId?: string;
     isPrimary?: boolean;
     parent?: string;
@@ -350,6 +354,7 @@ declare global {
     conceptIds?: Array<string>;
     concepts?: Array<GQLDetailedConcept>;
     relatedContent?: Array<GQLRelatedContent>;
+    availability?: string;
   }
   
   export interface GQLembedVisualelement {
@@ -1126,6 +1131,7 @@ declare global {
     metaDescription?: MetaToMetaDescriptionResolver<TParent>;
     metaImage?: MetaToMetaImageResolver<TParent>;
     lastUpdated?: MetaToLastUpdatedResolver<TParent>;
+    availability?: MetaToAvailabilityResolver<TParent>;
   }
   
   export interface MetaToIdResolver<TParent = any, TResult = any> {
@@ -1149,6 +1155,10 @@ declare global {
   }
   
   export interface MetaToLastUpdatedResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface MetaToAvailabilityResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1418,6 +1428,7 @@ declare global {
     learningpath?: ResourceToLearningpathResolver<TParent>;
     filters?: ResourceToFiltersResolver<TParent>;
     rank?: ResourceToRankResolver<TParent>;
+    availability?: ResourceToAvailabilityResolver<TParent>;
     relevanceId?: ResourceToRelevanceIdResolver<TParent>;
     resourceTypes?: ResourceToResourceTypesResolver<TParent>;
     parentTopics?: ResourceToParentTopicsResolver<TParent>;
@@ -1473,6 +1484,10 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface ResourceToAvailabilityResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface ResourceToRelevanceIdResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
@@ -1500,6 +1515,7 @@ declare global {
     article?: TopicToArticleResolver<TParent>;
     filters?: TopicToFiltersResolver<TParent>;
     rank?: TopicToRankResolver<TParent>;
+    availability?: TopicToAvailabilityResolver<TParent>;
     relevanceId?: TopicToRelevanceIdResolver<TParent>;
     isPrimary?: TopicToIsPrimaryResolver<TParent>;
     parent?: TopicToParentResolver<TParent>;
@@ -1552,6 +1568,10 @@ declare global {
   }
   
   export interface TopicToRankResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface TopicToAvailabilityResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -1968,6 +1988,7 @@ declare global {
     conceptIds?: ArticleToConceptIdsResolver<TParent>;
     concepts?: ArticleToConceptsResolver<TParent>;
     relatedContent?: ArticleToRelatedContentResolver<TParent>;
+    availability?: ArticleToAvailabilityResolver<TParent>;
   }
   
   export interface ArticleToIdResolver<TParent = any, TResult = any> {
@@ -2075,6 +2096,10 @@ declare global {
   }
   
   export interface ArticleToRelatedContentResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleToAvailabilityResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/utils/articleHelpers.ts
+++ b/src/utils/articleHelpers.ts
@@ -56,13 +56,23 @@ export async function filterMissingArticles(
     ),
   );
   const nonNullArticles = articles.filter(article => !!article);
-  return [
-    ...learningpathResources,
-    ...articleResources.filter(taxonomyEntity =>
-      nonNullArticles.find(
-        article =>
-          getArticleIdFromUrn(taxonomyEntity.contentUri) === `${article.id}`,
-      ),
+
+  const activeResources = articleResources.filter(taxonomyEntity =>
+    nonNullArticles.find(
+      article =>
+        getArticleIdFromUrn(taxonomyEntity.contentUri) === `${article.id}`,
     ),
-  ];
+  );
+
+  const withAvailability = activeResources.map(taxonomyEntity => {
+    const article = nonNullArticles.find(
+      a => getArticleIdFromUrn(taxonomyEntity.contentUri) === `${a.id}`,
+    );
+    return {
+      ...taxonomyEntity,
+      availability: article.availability,
+    };
+  });
+
+  return [...learningpathResources, ...withAvailability];
 }


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2751

Henter availability fra article-api og hekter på taksonomiemne eller ressurs.
Henter også relevanceId fra parent topic.