### PR TITLE
Avoid caching results with restrictive cache-control headers

### DIFF
--- a/src/resolvers/__tests__/subjectResolver-test.ts
+++ b/src/resolvers/__tests__/subjectResolver-test.ts
@@ -10,6 +10,9 @@ const nock = require('nock');
 import DataLoader from 'dataloader';
 import { Query } from '../subjectResolvers';
 
+const mockRequest: any = {};
+const mockResponse: any = {};
+
 test('Fetch subject should filter out invisible elements', async () => {
   const subjects = [
     {
@@ -43,6 +46,8 @@ test('Fetch subject should filter out invisible elements', async () => {
   const subjectsLoader = new DataLoader(loadAll);
 
   const subs = await Query.subjects(1, 1, {
+    req: mockRequest,
+    res: mockResponse,
     language: 'nb',
     shouldUseCache: false,
     taxonomyUrl: 'taxonomy',
@@ -76,6 +81,8 @@ test('Fetch subject filters should filter out invisible elements', async () => {
     ]);
 
   const subs = await Query.filters(1, 1, {
+    req: mockRequest,
+    res: mockResponse,
     language: 'nb',
     shouldUseCache: false,
     taxonomyUrl: 'taxonomy',

--- a/src/resolvers/__tests__/subjectResolver-test.ts
+++ b/src/resolvers/__tests__/subjectResolver-test.ts
@@ -8,10 +8,15 @@
 
 const nock = require('nock');
 import DataLoader from 'dataloader';
+import { Request, Response } from 'express';
 import { Query } from '../subjectResolvers';
 
-const mockRequest: any = {};
-const mockResponse: any = {};
+const mockRequest = {} as Request;
+const mockResponse = {
+  getHeader: (name: string, value: string): string | null => {
+    return null;
+  },
+} as Response;
 
 test('Fetch subject should filter out invisible elements', async () => {
   const subjects = [

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,8 +55,13 @@ function getFeideAuthorization(request: Request): string | null {
 
 function getShouldUseCache(request: Request): boolean {
   const cacheControl = request.headers['cache-control']?.toLowerCase();
+  const feideAuthHeader = getFeideAuthorization(request);
   const disableCacheHeaders = ['no-cache', 'no-store'];
-  return !disableCacheHeaders.includes(cacheControl);
+
+  const cacheControlDisable = disableCacheHeaders.includes(cacheControl);
+  const feideHeaderPresent = !!feideAuthHeader;
+
+  return !cacheControlDisable && !feideHeaderPresent;
 }
 
 const getTaxonomyUrl = (request: Request): string => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,8 +54,9 @@ function getFeideAuthorization(request: Request): string | null {
 }
 
 function getShouldUseCache(request: Request): boolean {
-  const cacheControl = request.headers['cache-control'];
-  return cacheControl !== 'no-cache';
+  const cacheControl = request.headers['cache-control']?.toLowerCase();
+  const disableCacheHeaders = ['no-cache', 'no-store'];
+  return !disableCacheHeaders.includes(cacheControl);
 }
 
 const getTaxonomyUrl = (request: Request): string => {
@@ -63,7 +64,13 @@ const getTaxonomyUrl = (request: Request): string => {
   return taxonomyUrl === 'true' ? 'taxonomy2' : 'taxonomy';
 };
 
-async function getContext({ req }: { req: Request }): Promise<Context> {
+async function getContext({
+  req,
+  res,
+}: {
+  req: Request;
+  res: Response;
+}): Promise<Context> {
   const token = await getToken(req);
   const feideAuthorization = getFeideAuthorization(req);
 
@@ -76,6 +83,8 @@ async function getContext({ req }: { req: Request }): Promise<Context> {
     feideAuthorization,
     shouldUseCache,
     taxonomyUrl,
+    req,
+    res,
   };
 
   return {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
-import { RequestInit, RequestCache, Headers } from 'node-fetch';
-import express, { Request, Response } from 'express';
+import { RequestInit, RequestCache } from 'node-fetch';
+import { Request, Response } from 'express';
 import { FrontpageResponse } from '../api/frontpageApi';
 
 declare global {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader';
-import { RequestInit, RequestCache } from 'node-fetch';
+import { RequestInit, RequestCache, Headers } from 'node-fetch';
+import express, { Request, Response } from 'express';
 import { FrontpageResponse } from '../api/frontpageApi';
 
 declare global {
@@ -10,6 +11,8 @@ declare global {
   }
 
   interface Context {
+    req: Request;
+    res: Response;
     token?: AuthToken;
     feideAuthorization?: string;
     language: string;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -35,6 +35,7 @@ async function fetchHelper(
   const fetchFn = createFetch({
     cache,
     disableCache: !context.shouldUseCache,
+    context,
   });
 
   const accessTokenAuth = context.token

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -56,7 +56,7 @@ async function fetchHelper(
     ...cacheHeaders,
   };
 
-  return fetchFn(apiResourceUrl(path), {
+  return fetchFn(apiResourceUrl(path), context, {
     headers,
     ...options,
   });


### PR DESCRIPTION
Denne gjør at `cache-control` headere blir lest fra alle responser og ikke cacher de dersom de er restriktive (en av `no-store`, `private` og `no-cache`). Samtidig så vidrefører den responsheaderen til graphql responsen.

Kan testes ved å sjekke at private ting ikke caches, og at de får med seg responsheaderen.

Forslag til en query som henter noe privat i test (Her må man sende med et feide token som header):
`FeideAuthorization: Bearer <feideToken>`
```gql
article(id: "22341") {
  id
  title
  availability
}
```