### PR TITLE
forces parent for topic to be set by using subjectId

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -107,7 +107,7 @@ export async function fetchSubjectTopics(
   subjectId: string,
   filterIds: string,
   context: Context,
-) {
+): Promise<GQLTopic[]> {
   const filterParam = filterIds ? `&filter=${filterIds}` : '';
   const response = await fetch(
     `/${context.taxonomyUrl}/v1/subjects/${subjectId}/topics/?recursive=true&language=${context.language}${filterParam}`,

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -15,6 +15,7 @@ import {
   fetchSubtopics,
   fetchOembed,
   fetchSubject,
+  fetchSubjectTopics,
 } from '../api';
 import {
   filterMissingArticles,
@@ -33,9 +34,13 @@ interface TopicResponse {
 export const Query = {
   async topic(
     _: any,
-    { id }: QueryToTopicArgs,
+    { id, subjectId }: QueryToTopicArgs,
     context: Context,
   ): Promise<GQLTopic> {
+    if (subjectId) {
+      const topics = await fetchSubjectTopics(subjectId, '', context);
+      return topics.find(topic => topic.id === id);
+    }
     return fetchTopic({ id }, context);
   },
   async topics(


### PR DESCRIPTION
Fixes NDLANO/Issues#2909

Bruker subjectId for å være sikker på at emne hentes i en kontekst. Vil _kanskje_ kunne ha en ytelseshit, men antar caching håndterer dette for det meste.

Test
* Kjør denne lokalt og åpne sida /subject:1:ca607ca1-4dd0-4bbd-954f-67461f4b96fc/topic:1:89f902cb-98f4-4acc-be79-d3e2f40a8bf1/topic:1:108969b4-7e6f-4cfd-82b4-4d759df8b793/?disableSSR=true
* Når du åpner menyen skal ikkje styrke ligge på rota som det skjer på ndla.no
* Sjekk gjerne også at det som returneres fra graphql har parent satt.