### PR TITLE
Fikser henting av kompetansemål med språkkode nb.

### DIFF
--- a/src/utils/__tests__/mapping-test.ts
+++ b/src/utils/__tests__/mapping-test.ts
@@ -1,0 +1,7 @@
+import { isoLanguageMapping } from '../mapping';
+
+test('isoLanguageMapping should work', () => {
+  expect(isoLanguageMapping['nn']).toBe('nno');
+  expect(isoLanguageMapping['nb']).toBe('nob');
+  expect(isoLanguageMapping['no']).toBe('nob');
+});

--- a/src/utils/mapping.ts
+++ b/src/utils/mapping.ts
@@ -11,6 +11,7 @@ export const curriculumLanguageMapping: {
 } = {
   en: 'http://psi.oasis-open.org/iso/639/#eng',
   nb: 'http://psi.oasis-open.org/iso/639/#nob',
+  no: 'http://psi.oasis-open.org/iso/639/#nob',
   nn: 'http://psi.oasis-open.org/iso/639/#nno',
 };
 
@@ -18,7 +19,9 @@ export const isoLanguageMapping: {
   [index: string]: string;
 } = {
   en: 'eng',
+  nb: 'nob',
   no: 'nob',
   nn: 'nno',
+  se: 'sme',
   sma: 'sma',
 };


### PR DESCRIPTION
Vi mangla mapping fra nb til nob. La også til se (nordsamisk)

Test:
* Må kjøres lokalt
* Start ndla-frontend med `start-with-local-graphql`
* Gå til http://localhost:3000/subject:1:470720f9-6b03-40cb-ab58-e3e130803578/ og sjekk at tekstene for kompetansemål er bokmål.