### PR TITLE
Added tag filtering constrained by chosen subjects

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -159,8 +159,12 @@ export async function fetchListingPage(
   });
   const tags = await resolveJson(
     await fetch(`/concept-api/v1/concepts/tags/?${params}`, context),
-  ).catch(_ => {
-    return [{ tags: [] }];
+  ).catch(error => {
+    if (error.status !== 404) {
+      throw error;
+    } else {
+      return [{ tags: [] }];
+    }
   });
   return {
     subjects,

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -168,17 +168,19 @@ export async function fetchListingPage(
   };
 }
 
-const isStringArray = (
-  tags: string[] | { tags: string[] }[],
-): tags is string[] => {
-  return !tags.some(tag => typeof tag !== 'string');
+interface TagType {
+  tags: string[];
+}
+
+const isStringArray = (tags: string[] | TagType[]): tags is string[] => {
+  return !tags.some((tag: string | TagType) => typeof tag !== 'string');
 };
 
-const getTags = (tags: string[] | { tags: string[] }[]) => {
+const getTags = (tags: string[] | TagType[]) => {
   if (isStringArray(tags)) {
     return tags;
   } else if (tags.length > 0) {
-    return uniq(tags.flatMap(tags => tags.tags));
+    return uniq(tags.flatMap(t => t.tags));
   }
   return [];
 };

--- a/src/resolvers/conceptResolvers.ts
+++ b/src/resolvers/conceptResolvers.ts
@@ -31,10 +31,10 @@ export const Query = {
   },
   async listingPage(
     _: any,
-    __: any,
+    args: QueryToListingPageArgs,
     context: Context,
   ): Promise<GQLListingPage> {
-    return fetchListingPage(context);
+    return fetchListingPage(context, args.subjects);
   },
   async conceptSearch(
     _: any,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -788,7 +788,7 @@ export const typeDefs = gql`
       grepCodes: String
       aggregatePaths: [String]
     ): [GroupSearch!]
-    listingPage: ListingPage
+    listingPage(subjects: String): ListingPage
     concepts(ids: [String!]): [Concept!]
     detailedConcept(id: String): DetailedConcept
     conceptSearch(

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -3608,8 +3608,11 @@ declare global {
     (parent: TParent, args: QueryToGroupSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface QueryToListingPageArgs {
+    subjects?: string;
+  }
   export interface QueryToListingPageResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+    (parent: TParent, args: QueryToListingPageArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
   export interface QueryToConceptsArgs {


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2920

Responsen man får fra backend er litt vanskelig å håndtere. Hvis man ikke passerer inn et subject får man tilbake en liste med strenger. Hvis man passerer inn et subject som ikke har noen tags returneres det en 404. Velger istedenfor å returnere et tomt array i slike tilfeller. Hvis man passerer inn et subject som har tags returneres et objekt. 