### PR TITLE
Made more of the audio schema properties required

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -12,6 +12,10 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 import { fetchSubject } from './taxonomyApi';
 import { fetchImage, parseVisualElement } from '../utils/visualelementHelpers';
 
+interface Author {
+  type: string;
+  name: string;
+}
 interface ConceptSearchResultJson extends SearchResultJson {
   tags?: {
     tags: string[];
@@ -23,6 +27,9 @@ interface ConceptSearchResultJson extends SearchResultJson {
     license: {
       license: string;
     };
+    processors: Author[];
+    rightsholders: Author[];
+    creators: Author[];
   };
   articleIds?: string[];
   subjectIds?: string[];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -816,8 +816,8 @@ export const typeDefs = gql`
       languageFilter: String
       relevance: String
     ): Search
-    podcast(id: String): Audio
-    podcastSearch(page: String, pageSize: String): AudioSearch
+    podcast(id: String!): Audio
+    podcastSearch(page: String, pageSize: String): AudioSearch!
   }
 `;
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -25,7 +25,7 @@ export const typeDefs = gql`
   }
 
   type Tags {
-    tags: [String!]
+    tags: [String!]!
     language: String!
   }
 
@@ -52,19 +52,19 @@ export const typeDefs = gql`
     title: Title!
     audioFile: AudioFile!
     copyright: Copyright!
-    tags: Tags
-    supportedLanguages: [String!]
+    tags: Tags!
+    supportedLanguages: [String!]!
     audioType: String!
     podcastMeta: PodcastMeta
     manuscript: Manuscript
   }
 
   type AudioSearch {
-    pageSize: Int
+    pageSize: Int!
     page: Int
-    language: String
-    totalCount: Int
-    results: [Audio!]
+    language: String!
+    totalCount: Int!
+    results: [Audio!]!
   }
 
   type ResourceTypeDefinition {
@@ -229,10 +229,10 @@ export const typeDefs = gql`
   }
 
   type Copyright {
-    license: License
-    creators: [Contributor!]
-    processors: [Contributor!]
-    rightsholders: [Contributor!]
+    license: License!
+    creators: [Contributor!]!
+    processors: [Contributor!]!
+    rightsholders: [Contributor!]!
     origin: String
   }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -865,8 +865,8 @@ export const typeDefs = gql`
     ): Search
     podcast(id: Int!): Audio
     podcastSearch(page: Int, pageSize: Int): AudioSearch!
-    podcastSeries(id: Int): PodcastSeries
-    podcastSeriesSearch(page: Int, pageSize: Int): PodcastSeriesSearch
+    podcastSeries(id: Int!): PodcastSeries
+    podcastSeriesSearch(page: Int, pageSize: Int): PodcastSeriesSearch!
   }
 `;
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -794,7 +794,7 @@ declare global {
     frontpageSearch?: GQLFrontpageSearch;
     searchWithoutPagination?: GQLSearch;
     podcast?: GQLAudio;
-    podcastSearch?: GQLAudioSearch;
+    podcastSearch: GQLAudioSearch;
   }
   
   /*********************************
@@ -3669,7 +3669,7 @@ declare global {
   }
   
   export interface QueryToPodcastArgs {
-    id?: string;
+    id: string;
   }
   export interface QueryToPodcastResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -843,7 +843,7 @@ declare global {
     podcast?: GQLAudio;
     podcastSearch: GQLAudioSearch;
     podcastSeries?: GQLPodcastSeries;
-    podcastSeriesSearch?: GQLPodcastSeriesSearch;
+    podcastSeriesSearch: GQLPodcastSeriesSearch;
   }
   
   /*********************************
@@ -3915,7 +3915,7 @@ declare global {
   }
   
   export interface QueryToPodcastSeriesArgs {
-    id?: number;
+    id: number;
   }
   export interface QueryToPodcastSeriesResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastSeriesArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -76,7 +76,7 @@ declare global {
     id: number;
     title: GQLTitle;
     description: GQLDescription;
-    supportedLanguages?: Array<string>;
+    supportedLanguages: Array<string>;
     episodes?: Array<GQLAudio>;
     coverPhoto: GQLCoverPhoto;
   }
@@ -87,8 +87,7 @@ declare global {
     audioType: string;
     url: string;
     license: string;
-    tags?: GQLTags;
-    supportedLanguages?: Array<string>;
+    supportedLanguages: Array<string>;
     manuscript?: GQLManuscript;
     podcastMeta?: GQLPodcastMeta;
     series?: GQLPodcastSeries;
@@ -117,7 +116,7 @@ declare global {
     page?: number;
     language: string;
     totalCount: number;
-    results?: Array<GQLPodcastSeriesSummary>;
+    results: Array<GQLPodcastSeriesSummary>;
   }
   
   export interface GQLResourceTypeDefinition {
@@ -1177,7 +1176,6 @@ declare global {
     audioType?: AudioSummaryToAudioTypeResolver<TParent>;
     url?: AudioSummaryToUrlResolver<TParent>;
     license?: AudioSummaryToLicenseResolver<TParent>;
-    tags?: AudioSummaryToTagsResolver<TParent>;
     supportedLanguages?: AudioSummaryToSupportedLanguagesResolver<TParent>;
     manuscript?: AudioSummaryToManuscriptResolver<TParent>;
     podcastMeta?: AudioSummaryToPodcastMetaResolver<TParent>;
@@ -1202,10 +1200,6 @@ declare global {
   }
   
   export interface AudioSummaryToLicenseResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface AudioSummaryToTagsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -30,7 +30,7 @@ declare global {
   }
   
   export interface GQLTags {
-    tags?: Array<string>;
+    tags: Array<string>;
     language: string;
   }
   
@@ -57,19 +57,19 @@ declare global {
     title: GQLTitle;
     audioFile: GQLAudioFile;
     copyright: GQLCopyright;
-    tags?: GQLTags;
-    supportedLanguages?: Array<string>;
+    tags: GQLTags;
+    supportedLanguages: Array<string>;
     audioType: string;
     podcastMeta?: GQLPodcastMeta;
     manuscript?: GQLManuscript;
   }
   
   export interface GQLAudioSearch {
-    pageSize?: number;
+    pageSize: number;
     page?: number;
-    language?: string;
-    totalCount?: number;
-    results?: Array<GQLAudio>;
+    language: string;
+    totalCount: number;
+    results: Array<GQLAudio>;
   }
   
   export interface GQLResourceTypeDefinition {
@@ -256,10 +256,10 @@ declare global {
   }
   
   export interface GQLCopyright {
-    license?: GQLLicense;
-    creators?: Array<GQLContributor>;
-    processors?: Array<GQLContributor>;
-    rightsholders?: Array<GQLContributor>;
+    license: GQLLicense;
+    creators: Array<GQLContributor>;
+    processors: Array<GQLContributor>;
+    rightsholders: Array<GQLContributor>;
     origin?: string;
   }
   


### PR DESCRIPTION
Begynte å stusse på noen av returtypene fra GraphQL ting mens jeg jobbet i NDLA-frontend. Etter å ha tittet litt fant jeg en del forskjeller mellom schema.ts og de faktiske typene i backenden. Mye av problemet ser ut til at vi ofte bruker `[String!]` istedenfor `[String!]!`, men det er et par andre felter som helt fint kan være required.