### PR TITLE
Returnerer visual element fra søk.

### DIFF
--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -65,13 +65,25 @@ export async function searchConcepts(
     page: conceptResult.page,
     pageSize: conceptResult.pageSize,
     language: conceptResult.language,
-    concepts: conceptResult.results.map((res: ConceptSearchResultJson) => ({
-      id: res.id,
-      title: res.title.title,
-      content: res.content.content,
-      tags: res.tags?.tags || [],
-      metaImage: res.metaImage,
-    })),
+    concepts: conceptResult.results?.map(
+      async (res: ConceptSearchResultJson) => {
+        const result: GQLConcept = {
+          id: res.id,
+          title: res.title.title,
+          content: res.content.content,
+          tags: res.tags?.tags || [],
+          subjectIds: res.subjectIds || [],
+          metaImage: res.metaImage,
+        };
+        if (res.visualElement) {
+          result.visualElement = await parseVisualElement(
+            res.visualElement.visualElement,
+            context,
+          );
+        }
+        return result;
+      },
+    ),
   };
 }
 
@@ -87,14 +99,21 @@ export async function fetchConcepts(
           context,
         );
         try {
-          const res: SearchResultJson = await resolveJson(concept);
+          const res: ConceptSearchResultJson = await resolveJson(concept);
           const result: GQLConcept = {
             id: res.id,
             title: res.title.title,
             content: res.content.content,
+            tags: res.tags?.tags || [],
+            subjectIds: res.subjectIds || [],
             metaImage: res.metaImage,
-            tags: res.tags?.tags ?? [],
           };
+          if (res.visualElement) {
+            result.visualElement = await parseVisualElement(
+              res.visualElement.visualElement,
+              context,
+            );
+          }
           return result;
         } catch (e) {
           return undefined;

--- a/src/resolvers/conceptResolvers.ts
+++ b/src/resolvers/conceptResolvers.ts
@@ -46,6 +46,22 @@ export const Query = {
 };
 
 export const resolvers = {
+  Concept: {
+    async subjectNames(
+      concept: GQLConcept,
+      _: any,
+      context: Context,
+    ): Promise<string[]> {
+      const data = await context.loaders.subjectsLoader.load('all');
+      if (concept.subjectIds?.length > 0) {
+        return Promise.all(
+          concept.subjectIds?.map(id => {
+            return data.subjects.find(subject => subject.id === id).name;
+          }),
+        );
+      }
+    },
+  },
   DetailedConcept: {
     async subjectNames(
       detailedConcept: GQLDetailedConcept,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -689,7 +689,10 @@ export const typeDefs = gql`
     title: String!
     content: String!
     tags: [String!]!
+    subjectIds: [String!]
+    subjectNames: [String!]
     metaImage: MetaImage!
+    visualElement: VisualElement
   }
 
   type DetailedConcept {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -727,7 +727,10 @@ declare global {
     title: string;
     content: string;
     tags: Array<string>;
+    subjectIds?: Array<string>;
+    subjectNames?: Array<string>;
     metaImage: GQLMetaImage;
+    visualElement?: GQLVisualElement;
   }
   
   export interface GQLDetailedConcept {
@@ -3352,7 +3355,10 @@ declare global {
     title?: ConceptToTitleResolver<TParent>;
     content?: ConceptToContentResolver<TParent>;
     tags?: ConceptToTagsResolver<TParent>;
+    subjectIds?: ConceptToSubjectIdsResolver<TParent>;
+    subjectNames?: ConceptToSubjectNamesResolver<TParent>;
     metaImage?: ConceptToMetaImageResolver<TParent>;
+    visualElement?: ConceptToVisualElementResolver<TParent>;
   }
   
   export interface ConceptToIdResolver<TParent = any, TResult = any> {
@@ -3371,7 +3377,19 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface ConceptToSubjectIdsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptToSubjectNamesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface ConceptToMetaImageResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ConceptToVisualElementResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
NDLANO/Issues#2960

https://github.com/NDLANO/Issues/issues/2989 bør fikses før dette tas i bruk for å unngå at søket returnerer tomt.

Gjør det mulig å vise utvida informasjon om forklaring fra søk. 