### PR TITLE
Improved the types used in frontpageResolvers and frontpageApi and cleaned up Context.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "query-string": "^6.2.0"
   },
   "devDependencies": {
+    "@ndla/types-frontpage-api": "^0.0.3",
+    "@ndla/types-article-api": "^0.0.4",
     "@types/bunyan": "^1.8.5",
     "@types/compression": "^1.7.2",
     "@types/cors": "^2.8.4",

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { IArticleSummaryV2, ISearchResultV2 } from '@ndla/types-article-api';
 import { localConverter, ndlaUrl } from '../config';
 import { fetch, resolveJson } from '../utils/apiHelpers';
 import { getArticleIdFromUrn, findPrimaryPath } from '../utils/articleHelpers';
@@ -166,26 +167,18 @@ export async function fetchArticles(
   });
 }
 
-export async function fetchMovieMeta(
+export async function fetchSimpleArticle(
   articleUrn: string,
   context: Context,
-): Promise<GQLMovieMeta> {
+): Promise<IArticleSummaryV2 | undefined> {
   const articleId = getArticleIdFromUrn(articleUrn);
   const response = await fetch(
     `/article-api/v2/articles/?ids=${articleId}&language=${context.language}&license=all&fallback=true`,
     context,
   );
-  const json = await resolveJson(response);
-  const article = json.results.find((item: { id: number }) => {
+  const json: ISearchResultV2 = await resolveJson(response);
+  const article: IArticleSummaryV2 | undefined = json.results.find(item => {
     return item.id.toString() === articleId;
   });
-
-  if (article) {
-    return {
-      title: article.title.title,
-      metaDescription: article.metaDescription?.metaDescription,
-      metaImage: article.metaImage,
-    };
-  }
-  return null;
+  return article;
 }

--- a/src/api/frontpageApi.ts
+++ b/src/api/frontpageApi.ts
@@ -6,48 +6,61 @@
  *
  */
 
+import {
+  IFrontPageData,
+  IFilmFrontPageData,
+  ISubjectPageData,
+} from '@ndla/types-frontpage-api';
 import { fetch, resolveJson } from '../utils/apiHelpers';
+import { fetchSimpleArticle } from './articleApi';
 
-export interface RSubjectCategory {
-  id: string;
-  filters: string[];
-}
-
-export interface RCategory {
-  name: string;
-  subjects: RSubjectCategory[];
-}
-export interface FrontpageResponse {
-  topical: string[];
-  categories: RCategory[];
+export interface IMovieMeta {
+  title: string;
+  metaDescription?: string;
+  metaImage?: {
+    url: string;
+    alt: string;
+    language: string;
+  };
 }
 
 export async function fetchFrontpage(
   context: Context,
-): Promise<FrontpageResponse> {
+): Promise<IFrontPageData> {
   const response = await fetch(`/frontpage-api/v1/frontpage/`, context);
-
-  const frontpage: FrontpageResponse = await resolveJson(response);
-
-  return frontpage;
+  return await resolveJson(response);
 }
 
 export async function fetchSubjectPage(
   subjectPageId: number,
   context: Context,
-): Promise<GQLSubjectPage> {
+): Promise<ISubjectPageData> {
   const response = await fetch(
     `/frontpage-api/v1/subjectpage/${subjectPageId}?language=${context.language}&fallback=true`,
     context,
   );
-  const subjectPage: GQLSubjectPage = await resolveJson(response);
-  return subjectPage;
+  return await resolveJson(response);
 }
 
 export async function fetchFilmFrontpage(
   context: Context,
-): Promise<GQLFilmFrontpage> {
+): Promise<IFilmFrontPageData> {
   const response = await fetch(`/frontpage-api/v1/filmfrontpage`, context);
-  const filmFrontpage: GQLFilmFrontpage = await resolveJson(response);
-  return filmFrontpage;
+  return await resolveJson(response);
+}
+
+export async function fetchMovieMeta(
+  articleUrn: string,
+  context: Context,
+): Promise<IMovieMeta | null> {
+  const article = await fetchSimpleArticle(articleUrn, context);
+
+  if (article) {
+    return {
+      title: article.title.title,
+      metaDescription: article.metaDescription?.metaDescription,
+      metaImage: article.metaImage,
+    };
+  }
+  return null;
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,8 +22,9 @@ export {
   fetchFrontpage,
   fetchSubjectPage,
   fetchFilmFrontpage,
+  fetchMovieMeta,
 } from './frontpageApi';
-export { fetchArticle, fetchArticles, fetchMovieMeta } from './articleApi';
+export { fetchArticle, fetchArticles } from './articleApi';
 export { fetchLearningpaths, fetchLearningpath } from './learningpathApi';
 export {
   fetchResource,

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -22,7 +22,7 @@ interface FetchTopicResourcesParams {
 
 export async function fetchResource(
   { id, subjectId, topicId }: QueryToResourceArgs,
-  context: Context,
+  context: ContextWithLoaders,
 ): Promise<GQLResource> {
   const response = await fetch(
     `/${context.taxonomyUrl}/v1/resources/${id}/full?language=${context.language}`,
@@ -153,8 +153,8 @@ export async function fetchTopicResources(
 }
 
 export async function fetchResourcesAndTopics(
-  params: { ids: [string]; subjectId?: string },
-  context: Context,
+  params: { ids: string[]; subjectId?: string },
+  context: ContextWithLoaders,
 ): Promise<GQLTaxonomyEntity[]> {
   const { ids, ...args } = params;
   return Promise.all(

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,12 +9,14 @@
 import { Request } from 'express';
 import { isString } from 'lodash';
 
-export async function getToken(request: Request): Promise<AuthToken | null> {
+export async function getToken(
+  request: Request,
+): Promise<AuthToken | undefined> {
   const authorization = request.headers.authorization;
 
   if (isString(authorization)) {
     return { access_token: authorization.replace('Bearer ', '') };
   }
 
-  return null;
+  return undefined;
 }

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { IFilmFrontPageData, IFrontPageData } from '@ndla/types-frontpage-api';
 import DataLoader from 'dataloader';
 import {
   fetchArticles,
@@ -18,7 +19,6 @@ import {
   fetchLK06Curriculum,
   fetchLK20Curriculum,
 } from './api';
-import { FrontpageResponse } from './api/frontpageApi';
 
 export function articlesLoader(context: Context): DataLoader<string, GQLMeta> {
   return new DataLoader(
@@ -74,7 +74,7 @@ export function lk06CurriculumLoader(
 
 export function frontpageLoader(
   context: Context,
-): DataLoader<string, FrontpageResponse> {
+): DataLoader<string, IFrontPageData> {
   return new DataLoader(async () => {
     const frontpage = await fetchFrontpage(context);
     return [frontpage];
@@ -83,7 +83,7 @@ export function frontpageLoader(
 
 export function filmFrontpageLoader(
   context: Context,
-): DataLoader<string, GQLFilmFrontpage> {
+): DataLoader<string, IFilmFrontPageData> {
   return new DataLoader(async () => {
     const filmFrontpage = await fetchFilmFrontpage(context);
     return [filmFrontpage];

--- a/src/resolvers/__tests__/subjectResolver-test.ts
+++ b/src/resolvers/__tests__/subjectResolver-test.ts
@@ -7,9 +7,12 @@
  */
 
 const nock = require('nock');
-import DataLoader from 'dataloader';
 import { Request, Response } from 'express';
 import { Query } from '../subjectResolvers';
+import {
+  mockLoaders,
+  mockSubjectsLoader,
+} from '../../utils/__tests__/mockLoaders';
 
 const mockRequest = {} as Request;
 const mockResponse = {
@@ -44,19 +47,16 @@ test('Fetch subject should filter out invisible elements', async () => {
     .get('/taxonomy/v1/subjects/?language=nb')
     .reply(200, subjects);
 
-  const loadAll = async () => {
-    return [{ subjects }];
-  };
-
-  const subjectsLoader = new DataLoader(loadAll);
-
   const subs = await Query.subjects(1, 1, {
     req: mockRequest,
     res: mockResponse,
     language: 'nb',
     shouldUseCache: false,
     taxonomyUrl: 'taxonomy',
-    loaders: { subjectsLoader },
+    loaders: {
+      ...mockLoaders,
+      subjectsLoader: mockSubjectsLoader(subjects),
+    },
   });
 
   expect(subs).toMatchSnapshot();

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -19,7 +19,7 @@ export const Query = {
   async article(
     _: any,
     { id, subjectId, isOembed, path }: QueryToArticleArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLArticle> {
     return fetchArticle(
       {
@@ -38,7 +38,7 @@ export const resolvers = {
     async competenceGoals(
       article: GQLArticle,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLCompetenceGoal[]> {
       const nodeId = article.oldNdlaUrl?.split('/').pop();
       const language =
@@ -49,7 +49,7 @@ export const resolvers = {
     async coreElements(
       article: GQLArticle,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLCoreElement[]> {
       const language =
         article.supportedLanguages.find(lang => lang === context.language) ||
@@ -59,7 +59,7 @@ export const resolvers = {
     async crossSubjectTopics(
       article: GQLArticle,
       args: { subjectId: string },
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLCrossSubjectElement[]> {
       const crossSubjectCodes = article.grepCodes.filter(code =>
         code.startsWith('TT'),
@@ -83,7 +83,7 @@ export const resolvers = {
     async concepts(
       article: GQLArticle,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLDetailedConcept[]> {
       return fetchDetailedConcepts(article.conceptIds, context);
     },

--- a/src/resolvers/conceptResolvers.ts
+++ b/src/resolvers/conceptResolvers.ts
@@ -18,28 +18,28 @@ export const Query = {
   async concepts(
     _: any,
     { ids }: QueryToConceptsArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLConcept[]> {
     return fetchConcepts(ids, context);
   },
   async detailedConcept(
     _: any,
     { id }: QueryToDetailedConceptArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLDetailedConcept> {
     return fetchDetailedConcept(id, context);
   },
   async listingPage(
     _: any,
     args: QueryToListingPageArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLListingPage> {
     return fetchListingPage(context, args.subjects);
   },
   async conceptSearch(
     _: any,
     searchQuery: QueryToConceptSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLConceptResult> {
     return searchConcepts(searchQuery, context);
   },
@@ -50,7 +50,7 @@ export const resolvers = {
     async subjectNames(
       concept: GQLConcept,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<string[]> {
       const data = await context.loaders.subjectsLoader.load('all');
       if (concept.subjectIds?.length > 0) {
@@ -66,7 +66,7 @@ export const resolvers = {
     async subjectNames(
       detailedConcept: GQLDetailedConcept,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<string[]> {
       const data = await context.loaders.subjectsLoader.load('all');
       if (detailedConcept.subjectIds?.length > 0) {
@@ -80,7 +80,7 @@ export const resolvers = {
     async articles(
       detailedConcept: GQLDetailedConcept,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLMeta[]> {
       if (detailedConcept.articleIds?.length > 0) {
         const articles = await fetchArticles(

--- a/src/resolvers/curriculumResolvers.ts
+++ b/src/resolvers/curriculumResolvers.ts
@@ -23,14 +23,14 @@ export const Query = {
       nodeId,
       language,
     }: { codes: string[]; nodeId?: string; language?: string },
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLCompetenceGoal[]> {
     return fetchCompetenceGoals(codes, nodeId, language, context);
   },
   async coreElements(
     _: any,
     { codes, language }: { codes: string[]; language?: string },
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLCoreElement[]> {
     if (codes?.length) {
       return fetchCoreElements(codes, language, context);
@@ -43,7 +43,7 @@ export const resolvers = {
     async curriculum(
       competenceGoal: GQLCompetenceGoal,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLReference> {
       if (competenceGoal.curriculumId) {
         return context.loaders.lk06CurriculumLoader.load(
@@ -58,7 +58,7 @@ export const resolvers = {
     async competenceGoalSet(
       competenceGoal: GQLCompetenceGoal,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLReference> {
       if (competenceGoal.competenceAimSetId) {
         return fetchLK06CompetenceGoalSet(
@@ -79,7 +79,7 @@ export const resolvers = {
     async crossSubjectTopics(
       competenceGoal: GQLCompetenceGoal,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLElement[]> {
       if (competenceGoal.crossSubjectTopicsCodes) {
         return fetchCrossSubjectTopics(
@@ -93,7 +93,7 @@ export const resolvers = {
     async coreElements(
       competenceGoal: GQLCompetenceGoal,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLElement[]> {
       if (competenceGoal.coreElementsCodes) {
         return fetchCoreElementReferences(
@@ -109,7 +109,7 @@ export const resolvers = {
     async curriculum(
       coreElement: GQLCoreElement,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLReference> {
       if (coreElement.curriculumCode) {
         return context.loaders.lk20CurriculumLoader.load({

--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -6,19 +6,14 @@
  *
  */
 
-import {
-  fetchLearningpath,
-  fetchResource,
-  fetchArticle,
-  fetchOembed,
-} from '../api';
+import { fetchLearningpath, fetchResource, fetchOembed } from '../api';
 import { isNDLAEmbedUrl } from '../utils/articleHelpers';
 
 export const Query = {
   async learningpath(
     _: any,
     { pathId }: QueryToLearningpathArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLLearningpath> {
     return fetchLearningpath(pathId, context);
   },
@@ -39,7 +34,7 @@ export const resolvers = {
     async oembed(
       learningpathStep: GQLLearningpathStep,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLLearningpathStepOembed> {
       if (!learningpathStep.embedUrl || !learningpathStep.embedUrl.url) {
         return null;
@@ -62,7 +57,7 @@ export const resolvers = {
     async resource(
       learningpathStep: GQLLearningpathStep,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLResource> {
       if (
         !learningpathStep.embedUrl ||

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -17,28 +17,28 @@ export const Query = {
   async podcast(
     _: any,
     { id }: QueryToPodcastArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLAudio> {
     return fetchPodcast(context, id);
   },
   async podcastSearch(
     _: any,
     { pageSize, page }: QueryToPodcastSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLAudioSearch> {
     return fetchPodcastsPage(context, pageSize, page);
   },
   async podcastSeries(
     _: any,
     { id }: QueryToPodcastSeriesArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLPodcastSeries> {
     return fetchPodcastSeries(context, id);
   },
   async podcastSeriesSearch(
     _: any,
     { pageSize, page }: QueryToPodcastSeriesSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLPodcastSeriesSearch> {
     return fetchPodcastSeriesPage(context, pageSize, page);
   },

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -26,14 +26,14 @@ export const Query = {
   async resource(
     _: any,
     { id, subjectId, topicId }: QueryToResourceArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLResource> {
     return fetchResource({ id, subjectId, topicId }, context);
   },
   async resourceTypes(
     _: any,
     __: any,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLResourceType[]> {
     return fetchResourceTypes(context);
   },
@@ -48,7 +48,11 @@ export const resolvers = {
     },
   },
   Resource: {
-    async availability(resource: GQLResource, _: any, context: Context) {
+    async availability(
+      resource: GQLResource,
+      _: any,
+      context: ContextWithLoaders,
+    ) {
       const defaultAvailability = 'everyone';
       if (resource.contentUri?.startsWith('urn:article')) {
         const article = await context.loaders.articlesLoader.load(
@@ -61,7 +65,7 @@ export const resolvers = {
     async meta(
       resource: GQLResource,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLMeta> {
       if (resource.contentUri?.startsWith('urn:learningpath')) {
         return context.loaders.learningpathsLoader.load(
@@ -80,7 +84,7 @@ export const resolvers = {
     async learningpath(
       resource: GQLResource,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLLearningpath> {
       if (resource.contentUri?.startsWith('urn:learningpath')) {
         const learningpathId = getLearningpathIdFromUrn(resource.contentUri);
@@ -103,7 +107,7 @@ export const resolvers = {
         subjectId?: string;
         isOembed?: string;
       },
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLArticle> {
       if (resource.contentUri?.startsWith('urn:article')) {
         const articleId = getArticleIdFromUrn(resource.contentUri);
@@ -141,7 +145,7 @@ export const resolvers = {
     async breadcrumbs(
       resource: GQLResource,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<string[][]> {
       return Promise.all(
         resource.paths?.map(async path => {

--- a/src/resolvers/searchResolvers.ts
+++ b/src/resolvers/searchResolvers.ts
@@ -17,28 +17,28 @@ export const Query = {
   async search(
     _: any,
     searchQuery: QueryToSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLSearch> {
     return search(searchQuery, context);
   },
   async groupSearch(
     _: any,
     searchQuery: QueryToSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLGroupSearch> {
     return groupSearch(searchQuery, context);
   },
   async frontpageSearch(
     _: any,
     searchQuery: QueryToSearchArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLFrontpageSearch> {
     return frontpageSearch(searchQuery, context);
   },
   async searchWithoutPagination(
     _: any,
     searchQuery: QueryToSearchWithoutPaginationArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLSearchWithoutPagination> {
     return searchWithoutPagination(searchQuery, context);
   },

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -34,7 +34,7 @@ export const Query = {
   async topic(
     _: any,
     { id, subjectId }: QueryToTopicArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLTopic> {
     if (subjectId) {
       const topics = await fetchSubjectTopics(subjectId, context);
@@ -45,7 +45,7 @@ export const Query = {
   async topics(
     _: any,
     { contentUri, filterVisible }: QueryToTopicsArgs,
-    context: Context,
+    context: ContextWithLoaders,
   ): Promise<GQLTopic[]> {
     const topicList = await fetchTopics({ contentUri }, context);
     if (!filterVisible) return topicList;
@@ -69,7 +69,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async availability(
       topic: TopicResponse,
       _: TopicToArticleArgs,
-      context: Context,
+      context: ContextWithLoaders,
     ) {
       const article = await context.loaders.articlesLoader.load(
         getArticleIdFromUrn(topic.contentUri),
@@ -79,7 +79,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async article(
       topic: TopicResponse,
       args: TopicToArticleArgs,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLArticle> {
       if (topic.contentUri && topic.contentUri.startsWith('urn:article')) {
         const articleId = getArticleIdFromUrn(topic.contentUri);
@@ -110,7 +110,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async meta(
       topic: TopicResponse,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLMeta> {
       if (topic.contentUri && topic.contentUri.startsWith('urn:article')) {
         return context.loaders.articlesLoader.load(
@@ -121,7 +121,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async coreResources(
       topic: TopicResponse,
       args: TopicToCoreResourcesArgs,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLResource[]> {
       const topicResources = await fetchTopicResources(
         {
@@ -136,7 +136,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async supplementaryResources(
       topic: TopicResponse,
       args: TopicToSupplementaryResourcesArgs,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLResource[]> {
       const topicResources = await fetchTopicResources(
         {
@@ -151,7 +151,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async subtopics(
       topic: TopicResponse,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLTopic[]> {
       const subtopics = await fetchSubtopics({ id: topic.id }, context);
       return filterMissingArticles(subtopics, context);
@@ -159,7 +159,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async pathTopics(
       topic: TopicResponse,
       _: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLTopic[][]> {
       return Promise.all(
         topic.paths?.map(async path => {
@@ -177,7 +177,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async alternateTopics(
       topic: TopicResponse,
       __: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<GQLTopic[]> {
       const { contentUri, id, path } = topic;
       if (!path) {
@@ -201,7 +201,7 @@ export const resolvers: { Topic: GQLTopicTypeResolver<TopicResponse> } = {
     async breadcrumbs(
       topic: TopicResponse,
       __: any,
-      context: Context,
+      context: ContextWithLoaders,
     ): Promise<string[][]> {
       return Promise.all(
         topic.paths?.map(async path => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,14 +42,14 @@ function getAcceptLanguage(request: Request): string {
   return 'nb';
 }
 
-function getFeideAuthorization(request: Request): string | null {
+function getFeideAuthorization(request: Request): string | undefined {
   // tslint:disable-next-line:no-string-literal
   const authorization = request.headers['feideauthorization'];
 
   if (isString(authorization)) {
     return authorization;
   }
-  return null;
+  return undefined;
 }
 
 function getShouldUseCache(request: Request): boolean {
@@ -74,7 +74,7 @@ async function getContext({
 }: {
   req: Request;
   res: Response;
-}): Promise<Context> {
+}): Promise<ContextWithLoaders> {
   const token = await getToken(req);
   const feideAuthorization = getFeideAuthorization(req);
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,13 +1,27 @@
 import DataLoader from 'dataloader';
 import { RequestInit, RequestCache } from 'node-fetch';
 import { Request, Response } from 'express';
-import { FrontpageResponse } from '../api/frontpageApi';
+import { IFrontPageData } from '@ndla/types-frontpage-api';
 
 declare global {
   interface AuthToken {
     access_token: string;
     expires_in?: number;
     token_type?: string;
+  }
+
+  interface Loaders {
+    articlesLoader: DataLoader<string, GQLMeta>;
+    learningpathsLoader: DataLoader<string, any>;
+    subjectTopicsLoader: DataLoader<{ subjectId: string }, any>;
+    subjectsLoader: DataLoader<string, { subjects: GQLSubject[] }>;
+    resourceTypesLoader: DataLoader<any, any>;
+    frontpageLoader: DataLoader<string, IFrontPageData>;
+    lk06CurriculumLoader: DataLoader<string, GQLReference>;
+    lk20CurriculumLoader: DataLoader<
+      { code: string; language: string },
+      GQLReference
+    >;
   }
 
   interface Context {
@@ -18,19 +32,10 @@ declare global {
     language: string;
     shouldUseCache: boolean;
     taxonomyUrl: string;
-    loaders?: {
-      articlesLoader?: DataLoader<string, GQLMeta>;
-      learningpathsLoader?: DataLoader<string, any>;
-      subjectTopicsLoader?: DataLoader<{ subjectId: string }, any>;
-      subjectsLoader?: DataLoader<string, { subjects: GQLSubject[] }>;
-      resourceTypesLoader?: DataLoader<any, any>;
-      frontpageLoader?: DataLoader<string, FrontpageResponse>;
-      lk06CurriculumLoader?: DataLoader<string, GQLReference>;
-      lk20CurriculumLoader?: DataLoader<
-        { code: string; language: string },
-        GQLReference
-      >;
-    };
+  }
+
+  interface ContextWithLoaders extends Context {
+    loaders: Loaders;
   }
 
   interface RequestOptions extends RequestInit {

--- a/src/utils/__tests__/mockLoaders.ts
+++ b/src/utils/__tests__/mockLoaders.ts
@@ -1,0 +1,78 @@
+import { IFilmFrontPageData, IFrontPageData } from '@ndla/types-frontpage-api';
+import DataLoader from 'dataloader';
+
+const mockFn = async <T>(mockData: T) => mockData;
+
+export const mockArticlesLoader = (mockData: GQLMeta[] = []) => {
+  return new DataLoader<string, GQLMeta>(() => mockFn(mockData));
+};
+
+export const mockLearningpathsLoader = (mockData: GQLMeta[] = []) => {
+  return new DataLoader<string, GQLMeta>(() => mockFn(mockData));
+};
+
+export const mockLk06CurriculumLoader = (mockData: GQLReference[] = []) => {
+  return new DataLoader<string, GQLReference>(() => mockFn(mockData));
+};
+
+export const mockLk20CurriculumLoader = (mockData: GQLReference[] = []) => {
+  return new DataLoader<{ code: string; language: string }, GQLReference>(() =>
+    mockFn(mockData),
+  );
+};
+
+export const mockFrontpageLoader = (
+  mockData: IFrontPageData[] = [mockFrontpageDefaultResponse],
+) => {
+  return new DataLoader<string, IFrontPageData>(() => mockFn(mockData));
+};
+
+export const mockFilmFrontpageLoader = (
+  mockData: IFilmFrontPageData[] = [mockFilmFrontPageDefaultResponse],
+) => {
+  return new DataLoader<string, IFilmFrontPageData>(() => mockFn(mockData));
+};
+
+export const mockSubjectsLoader = (mockData: GQLSubject[] = []) => {
+  return new DataLoader<string, { subjects: GQLSubject[] }>(async () => {
+    return [{ subjects: await mockFn(mockData) }];
+  });
+};
+
+export const mockSubjectTopicsLoader = (mockData: GQLTopic[] = []) => {
+  return new DataLoader<{ subjectId: string }, GQLTopic>(() =>
+    mockFn(mockData),
+  );
+};
+
+export const mockResourceTypesLoader = (
+  mockData: GQLResourceTypeDefinition[] = [],
+) => {
+  return new DataLoader<string, GQLResourceTypeDefinition>(() =>
+    mockFn(mockData),
+  );
+};
+
+export const mockFrontpageDefaultResponse: IFrontPageData = {
+  topical: [],
+  categories: [],
+};
+
+export const mockFilmFrontPageDefaultResponse: IFilmFrontPageData = {
+  name: '',
+  about: [],
+  movieThemes: [],
+  slideShow: [],
+};
+
+export const mockLoaders = {
+  articlesLoader: mockArticlesLoader(),
+  learningpathsLoader: mockLearningpathsLoader(),
+  lk06CurriculumLoader: mockLk06CurriculumLoader(),
+  lk20CurriculumLoader: mockLk20CurriculumLoader(),
+  frontpageLoader: mockFrontpageLoader(),
+  filmFrontpageLoader: mockFilmFrontpageLoader(),
+  subjectsLoader: mockSubjectTopicsLoader(),
+  subjectTopicsLoader: mockSubjectTopicsLoader(),
+  resourceTypesLoader: mockResourceTypesLoader(),
+};

--- a/src/utils/articleHelpers.ts
+++ b/src/utils/articleHelpers.ts
@@ -32,7 +32,7 @@ export function findPrimaryPath(
 
 export async function filterMissingArticles(
   entities: GQLTaxonomyEntity[],
-  context: Context,
+  context: ContextWithLoaders,
 ): Promise<GQLTaxonomyEntity[]> {
   const visibleEntities = entities.filter(taxonomyEntity =>
     taxonomyEntity.metadata ? taxonomyEntity.metadata.visible : true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,16 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
+"@ndla/types-article-api@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@ndla/types-article-api/-/types-article-api-0.0.4.tgz#5d48b9620b3df8165e9c773a68ec8ee13883b458"
+  integrity sha512-/3042WNFF4URUDMufkCEm+DSMIb+uWkKGWzb1KTTqQ3FhvihFP6Po3ISxphjODdKp/zbxWMH/QCgQYEsqZNNng==
+
+"@ndla/types-frontpage-api@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@ndla/types-frontpage-api/-/types-frontpage-api-0.0.3.tgz#31e6b1dba0b8a215c06b2918f34cfb0385192b0e"
+  integrity sha512-1sAwf7TyjAElbzvWjfLw1PI4pG9HQ+KArMNY8shDZnY3GiASko2GsJUxbTX/ryU85iTwkA9dPPR+Zuo6C9o9DA==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
Med TypeScript satt til `strict` ligger vi på rundt 160 typefeil. Denne PR'en fikser 50~ av de. 

Jeg flyttet `loaders` ut av context for å sørge for at de er typet som non-null i resolver-filene våre. Dette gjør det også enklere å se hvilke av funksjonene i API-filene som er avhengige av loaders. 