### PR TITLE
Fixed learningpath types. Fixed an error where coverphoto metaUrl never resolved properly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "@types/serve-static": "1.13.10"
   },
   "dependencies": {
+    "@graphql-tools/mock": "^8.2.2",
+    "@graphql-tools/schema": "^8.1.2",
+    "@ndla/types-learningpath-api": "^0.0.2",
     "apollo-server-express": "^3.1.2",
     "bunyan": "^1.8.12",
     "cheerio": "^1.0.0-rc.6",
@@ -36,8 +39,6 @@
     "express": "^4.17.1",
     "graphql": "^15.5.1",
     "graphql-scalars": "^1.10.0",
-    "@graphql-tools/schema": "^8.1.2",
-    "@graphql-tools/mock": "^8.2.2",
     "he": "^1.2.0",
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.3",
@@ -45,15 +46,14 @@
     "query-string": "^6.2.0"
   },
   "devDependencies": {
-    "@ndla/types-frontpage-api": "^0.0.3",
     "@ndla/types-article-api": "^0.0.4",
+    "@ndla/types-frontpage-api": "^0.0.3",
     "@types/bunyan": "^1.8.5",
     "@types/compression": "^1.7.2",
     "@types/cors": "^2.8.4",
     "@types/dotenv": "^6.1.0",
     "@types/express": "^4.17.13",
     "@types/express-serve-static-core": "^4.17.24",
-    "@types/serve-static": "1.13.10",
     "@types/graphql": "^14.5.0",
     "@types/he": "^1.1.1",
     "@types/jest": "^23.3.9",
@@ -63,6 +63,7 @@
     "@types/node": "^14.0.27",
     "@types/node-fetch": "^2.1.2",
     "@types/query-string": "^6.1.1",
+    "@types/serve-static": "1.13.10",
     "@zeit/ncc": "^0.22.3",
     "chalk": "^2.4.1",
     "concurrently": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@graphql-tools/mock": "^8.2.2",
     "@graphql-tools/schema": "^8.1.2",
-    "@ndla/types-learningpath-api": "^0.0.2",
     "apollo-server-express": "^3.1.2",
     "bunyan": "^1.8.12",
     "cheerio": "^1.0.0-rc.6",
@@ -48,6 +47,7 @@
   "devDependencies": {
     "@ndla/types-article-api": "^0.0.4",
     "@ndla/types-frontpage-api": "^0.0.3",
+    "@ndla/types-learningpath-api": "^0.0.2",
     "@types/bunyan": "^1.8.5",
     "@types/compression": "^1.7.2",
     "@types/cors": "^2.8.4",

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -29,7 +29,9 @@ export function articlesLoader(context: Context): DataLoader<string, GQLMeta> {
   );
 }
 
-export function learningpathsLoader(context: Context): DataLoader<string, any> {
+export function learningpathsLoader(
+  context: Context,
+): DataLoader<string, GQLMeta | null> {
   return new DataLoader(async learningpathIds => {
     return fetchLearningpaths(learningpathIds, context);
   });

--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -35,7 +35,7 @@ export const resolvers = {
       learningpathStep: GQLLearningpathStep,
       _: any,
       context: ContextWithLoaders,
-    ): Promise<GQLLearningpathStepOembed> {
+    ): Promise<GQLLearningpathStepOembed | null> {
       if (!learningpathStep.embedUrl || !learningpathStep.embedUrl.url) {
         return null;
       }
@@ -58,7 +58,7 @@ export const resolvers = {
       learningpathStep: GQLLearningpathStep,
       _: any,
       context: ContextWithLoaders,
-    ): Promise<GQLResource> {
+    ): Promise<GQLResource | null> {
       if (
         !learningpathStep.embedUrl ||
         !learningpathStep.embedUrl.url ||

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -173,7 +173,7 @@ export const typeDefs = gql`
   }
 
   type LearningpathCoverphoto {
-    url: String
+    url: String!
     metaUrl: String!
   }
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -178,7 +178,7 @@ declare global {
   }
   
   export interface GQLLearningpathCoverphoto {
-    url?: string;
+    url: string;
     metaUrl: string;
   }
   

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,11 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-frontpage-api/-/types-frontpage-api-0.0.3.tgz#31e6b1dba0b8a215c06b2918f34cfb0385192b0e"
   integrity sha512-1sAwf7TyjAElbzvWjfLw1PI4pG9HQ+KArMNY8shDZnY3GiASko2GsJUxbTX/ryU85iTwkA9dPPR+Zuo6C9o9DA==
 
+"@ndla/types-learningpath-api@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@ndla/types-learningpath-api/-/types-learningpath-api-0.0.2.tgz#6ae65f047ba8c7af32dd01ce800ec7254eee4e0e"
+  integrity sha512-pDBz2zL6e5iLUhI5muxxkHCk/ZF/Su+RHvuFkm21AlPAalKCyrssrJA9EiUwLQKanoTbOo0DinyVsaYAlrmsHA==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"


### PR DESCRIPTION
Schema-typen mente at metaUrl skulle returneres, mens denne ble erstattet med en alt-property i API'et. Dette burde ikke ha noen konsekvens for frontendene våre, da verdien ikke brukes uansett. Vi slipper dog å få tilbake et errors-array fra GraphQL på ndla-frontend sine læringsstier, der vi nå ber om feltet.