### PR TITLE
Add imageApi. Fetch detailed image data in podcastmeta

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@ndla/types-audio-api": "0.0.10",
     "@ndla/types-article-api": "^0.0.4",
+    "@ndla/types-image-api": "^0.0.4",
     "@ndla/types-frontpage-api": "^0.0.3",
     "@ndla/types-learningpath-api": "^0.0.2",
     "@types/bunyan": "^1.8.5",

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -15,7 +15,7 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 export async function fetchPodcast(
   context: Context,
   podcastId: number,
-): Promise<IAudioMetaInformation> {
+): Promise<IAudioMetaInformation | null> {
   const response = await fetch(`/audio-api/v1/audio/${podcastId}`, context);
   try {
     const audio = await resolveJson(response);

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -10,7 +10,8 @@ import queryString from 'query-string';
 import { uniq } from 'lodash';
 import { fetch, resolveJson } from '../utils/apiHelpers';
 import { fetchSubject } from './taxonomyApi';
-import { fetchImage, parseVisualElement } from '../utils/visualelementHelpers';
+import { parseVisualElement } from '../utils/visualelementHelpers';
+import { convertToSimpleImage, fetchImage } from './imageApi';
 
 interface Author {
   type: string;
@@ -159,7 +160,8 @@ export async function fetchDetailedConcept(
     };
     const metaImageId = concept.metaImage?.url?.split('/').pop();
     if (metaImageId) {
-      detailedConcept.image = await fetchImage(metaImageId, context);
+      const image = await fetchImage(metaImageId, context);
+      detailedConcept.image = image ? convertToSimpleImage(image) : undefined;
     }
     if (concept.visualElement) {
       detailedConcept.visualElement = await parseVisualElement(

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -12,12 +12,21 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 export async function fetchImage(
   imageId: string,
   context: Context,
-): Promise<IImageMetaInformationV2> {
+): Promise<IImageMetaInformationV2 | null> {
   const response = await fetch(`/image-api/v2/images/${imageId}`, context);
   try {
-    const image = await resolveJson(response);
-    return image;
+    return await resolveJson(response);
   } catch (e) {
     return null;
   }
+}
+
+export function convertToSimpleImage(image: IImageMetaInformationV2) {
+  return {
+    title: image.title.title,
+    src: image.imageUrl,
+    altText: image.alttext.alttext,
+    contentType: image.contentType,
+    copyright: image.copyright,
+  };
 }

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2022-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { IImageMetaInformationV2 } from '@ndla/types-image-api';
+import { fetch, resolveJson } from '../utils/apiHelpers';
+
+export async function fetchImage(
+  imageId: string,
+  context: Context,
+): Promise<IImageMetaInformationV2> {
+  const response = await fetch(`/image-api/v2/images/${imageId}`, context);
+  try {
+    const image = await resolveJson(response);
+    if (!image.id) {
+      return null;
+    }
+  } catch (e) {
+    return null;
+  }
+}

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -12,7 +12,7 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 export async function fetchImage(
   imageId: string,
   context: Context,
-): Promise<IImageMetaInformationV2 | null> {
+): Promise<IImageMetaInformationV2> {
   const response = await fetch(`/image-api/v2/images/${imageId}`, context);
   try {
     const image = await resolveJson(response);

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -12,13 +12,11 @@ import { fetch, resolveJson } from '../utils/apiHelpers';
 export async function fetchImage(
   imageId: string,
   context: Context,
-): Promise<IImageMetaInformationV2> {
+): Promise<IImageMetaInformationV2 | null> {
   const response = await fetch(`/image-api/v2/images/${imageId}`, context);
   try {
     const image = await resolveJson(response);
-    if (!image.id) {
-      return null;
-    }
+    return image;
   } catch (e) {
     return null;
   }

--- a/src/resolvers/conceptResolvers.ts
+++ b/src/resolvers/conceptResolvers.ts
@@ -13,7 +13,8 @@ import {
   fetchArticles,
 } from '../api';
 import { Concept, ConceptResult } from '../api/conceptApi';
-import { fetchImage, parseVisualElement } from '../utils/visualelementHelpers';
+import { convertToSimpleImage, fetchImage } from '../api/imageApi';
+import { parseVisualElement } from '../utils/visualelementHelpers';
 
 export const Query = {
   async concept(
@@ -69,7 +70,8 @@ export const resolvers = {
     async image(concept: Concept, _: any, context: ContextWithLoaders) {
       const metaImageId = concept.metaImage?.url?.split('/').pop();
       if (metaImageId) {
-        return await fetchImage(metaImageId, context);
+        const image = await fetchImage(metaImageId, context);
+        return convertToSimpleImage(image);
       }
       return undefined;
     },

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -23,7 +23,7 @@ export const Query = {
     _: any,
     { id }: QueryToPodcastArgs,
     context: ContextWithLoaders,
-  ): Promise<IAudioMetaInformation> {
+  ): Promise<IAudioMetaInformation | null> {
     return fetchPodcast(context, id);
   },
   async podcastSearch(
@@ -55,20 +55,20 @@ export const resolvers = {
       audio: IAudioMetaInformation,
       _: any,
       context: ContextWithLoaders,
-    ): Promise<GQLImageMetaInformation> {
-      const id = audio.podcastMeta.coverPhoto.id;
+    ): Promise<GQLImageMetaInformation | null> {
+      const id = audio.podcastMeta?.coverPhoto.id;
       if (!id) {
         return null;
       }
       const image = await fetchImage(id, context);
 
-      if (!image.id) {
+      if (!image) {
         return null;
       }
       return {
         ...image,
         title: image.title.title,
-        alttext: image.alttext.alttext,
+        altText: image.alttext.alttext,
         caption: image.caption.caption,
         tags: image.tags.tags,
       };

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -8,7 +8,6 @@
 
 import {
   IAudioMetaInformation,
-  IAudioSummary,
   IAudioSummarySearchResult,
 } from '@ndla/types-audio-api';
 import {
@@ -17,6 +16,7 @@ import {
   fetchPodcastSeriesPage,
   fetchPodcastsPage,
 } from '../api/audioApi';
+import { fetchImage } from '../api/imageApi';
 
 export const Query = {
   async podcast(
@@ -49,4 +49,29 @@ export const Query = {
   },
 };
 
-export const resolvers = {};
+export const resolvers = {
+  PodcastMeta: {
+    async image(
+      audio: IAudioMetaInformation,
+      _: any,
+      context: ContextWithLoaders,
+    ): Promise<GQLImageMetaInformation> {
+      const id = audio.podcastMeta.coverPhoto.id;
+      if (!id) {
+        return null;
+      }
+      const image = await fetchImage(id, context);
+
+      if (!image.id) {
+        return null;
+      }
+      return {
+        ...image,
+        title: image.title.title,
+        alttext: image.alttext.alttext,
+        caption: image.caption.caption,
+        tags: image.tags.tags,
+      };
+    },
+  },
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -351,7 +351,7 @@ export const typeDefs = gql`
     id: String!
     metaUrl: String!
     title: String!
-    alttext: String!
+    altText: String!
     imageUrl: String!
     size: Int!
     contentType: String!
@@ -953,9 +953,9 @@ export const typeDefs = gql`
       relevance: String
     ): SearchWithoutPagination
     podcast(id: Int!): AudioWithSeries
-    podcastSearch(page: Int, pageSize: Int): AudioSearch
+    podcastSearch(page: Int!, pageSize: Int!): AudioSearch
     podcastSeries(id: Int!): PodcastSeriesWithEpisodes
-    podcastSeriesSearch(page: Int, pageSize: Int): PodcastSeriesSearch
+    podcastSeriesSearch(page: Int!, pageSize: Int!): PodcastSeriesSearch
     alerts: [UptimeAlert]
   }
 `;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -347,16 +347,6 @@ export const typeDefs = gql`
     url: String
   }
 
-  type Title {
-    title: String!
-    language: String!
-  }
-
-  type AltText {
-    alttext: String!
-    language: String!
-  }
-
   type ImageMetaInformation {
     id: String!
     metaUrl: String!

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -42,7 +42,7 @@ export const typeDefs = gql`
 
   type PodcastMeta {
     introduction: String!
-    coverPhoto: CoverPhoto!
+    image: ImageMetaInformation
     language: String!
   }
 
@@ -347,6 +347,32 @@ export const typeDefs = gql`
     url: String
   }
 
+  type Title {
+    title: String!
+    language: String!
+  }
+
+  type AltText {
+    alttext: String!
+    language: String!
+  }
+
+  type ImageMetaInformation {
+    id: String!
+    metaUrl: String!
+    title: String!
+    alttext: String!
+    imageUrl: String!
+    size: Int!
+    contentType: String!
+    copyright: Copyright!
+    tags: [String!]!
+    caption: String!
+    supportedLanguages: [String!]!
+    created: String!
+    createdBy: String!
+  }
+
   type ImageLicense {
     title: String!
     src: String!
@@ -378,7 +404,6 @@ export const typeDefs = gql`
     iframe: BrightcoveIframe
     copyright: Copyright!
     uploadDate: String
-    copyText: String
   }
 
   type H5pLicense {
@@ -386,7 +411,6 @@ export const typeDefs = gql`
     src: String
     thumbnail: String
     copyright: Copyright!
-    copyText: String
   }
 
   type ConceptCopyright {
@@ -401,7 +425,6 @@ export const typeDefs = gql`
     title: String!
     src: String
     copyright: ConceptCopyright
-    copyText: String
   }
 
   type ArticleMetaData {
@@ -720,13 +743,11 @@ export const typeDefs = gql`
     download: String
     iframe: BrightcoveIframe
     uploadDate: String
-    copyText: String
   }
 
   type H5pElement {
     src: String
     thumbnail: String
-    copyText: String
   }
 
   type ListingPage {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -394,16 +394,11 @@ declare global {
     url?: string;
   }
   
-  export interface GQLAltText {
-    alttext: string;
-    language: string;
-  }
-  
   export interface GQLImageMetaInformation {
     id: string;
     metaUrl: string;
     title: string;
-    alttext: string;
+    altText: string;
     imageUrl: string;
     size: number;
     contentType: string;
@@ -1018,7 +1013,6 @@ declare global {
     Copyright?: GQLCopyrightTypeResolver;
     ArticleRequiredLibrary?: GQLArticleRequiredLibraryTypeResolver;
     FootNote?: GQLFootNoteTypeResolver;
-    AltText?: GQLAltTextTypeResolver;
     ImageMetaInformation?: GQLImageMetaInformationTypeResolver;
     ImageLicense?: GQLImageLicenseTypeResolver;
     AudioLicense?: GQLAudioLicenseTypeResolver;
@@ -2192,24 +2186,11 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLAltTextTypeResolver<TParent = any> {
-    alttext?: AltTextToAlttextResolver<TParent>;
-    language?: AltTextToLanguageResolver<TParent>;
-  }
-  
-  export interface AltTextToAlttextResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface AltTextToLanguageResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
   export interface GQLImageMetaInformationTypeResolver<TParent = any> {
     id?: ImageMetaInformationToIdResolver<TParent>;
     metaUrl?: ImageMetaInformationToMetaUrlResolver<TParent>;
     title?: ImageMetaInformationToTitleResolver<TParent>;
-    alttext?: ImageMetaInformationToAlttextResolver<TParent>;
+    altText?: ImageMetaInformationToAltTextResolver<TParent>;
     imageUrl?: ImageMetaInformationToImageUrlResolver<TParent>;
     size?: ImageMetaInformationToSizeResolver<TParent>;
     contentType?: ImageMetaInformationToContentTypeResolver<TParent>;
@@ -2233,7 +2214,7 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ImageMetaInformationToAlttextResolver<TParent = any, TResult = any> {
+  export interface ImageMetaInformationToAltTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -4292,8 +4273,8 @@ declare global {
   }
   
   export interface QueryToPodcastSearchArgs {
-    page?: number;
-    pageSize?: number;
+    page: number;
+    pageSize: number;
   }
   export interface QueryToPodcastSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -4307,8 +4288,8 @@ declare global {
   }
   
   export interface QueryToPodcastSeriesSearchArgs {
-    page?: number;
-    pageSize?: number;
+    page: number;
+    pageSize: number;
   }
   export interface QueryToPodcastSeriesSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastSeriesSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -47,7 +47,7 @@ declare global {
   
   export interface GQLPodcastMeta {
     introduction: string;
-    coverPhoto: GQLCoverPhoto;
+    image?: GQLImageMetaInformation;
     language: string;
   }
   
@@ -394,6 +394,27 @@ declare global {
     url?: string;
   }
   
+  export interface GQLAltText {
+    alttext: string;
+    language: string;
+  }
+  
+  export interface GQLImageMetaInformation {
+    id: string;
+    metaUrl: string;
+    title: string;
+    alttext: string;
+    imageUrl: string;
+    size: number;
+    contentType: string;
+    copyright: GQLCopyright;
+    tags: Array<string>;
+    caption: string;
+    supportedLanguages: Array<string>;
+    created: string;
+    createdBy: string;
+  }
+  
   export interface GQLImageLicense {
     title: string;
     src: string;
@@ -425,7 +446,6 @@ declare global {
     iframe?: GQLBrightcoveIframe;
     copyright: GQLCopyright;
     uploadDate?: string;
-    copyText?: string;
   }
   
   export interface GQLH5pLicense {
@@ -433,7 +453,6 @@ declare global {
     src?: string;
     thumbnail?: string;
     copyright: GQLCopyright;
-    copyText?: string;
   }
   
   export interface GQLConceptCopyright {
@@ -448,7 +467,6 @@ declare global {
     title: string;
     src?: string;
     copyright?: GQLConceptCopyright;
-    copyText?: string;
   }
   
   export interface GQLArticleMetaData {
@@ -778,13 +796,11 @@ declare global {
     download?: string;
     iframe?: GQLBrightcoveIframe;
     uploadDate?: string;
-    copyText?: string;
   }
   
   export interface GQLH5pElement {
     src?: string;
     thumbnail?: string;
-    copyText?: string;
   }
   
   export interface GQLListingPage {
@@ -1002,6 +1018,8 @@ declare global {
     Copyright?: GQLCopyrightTypeResolver;
     ArticleRequiredLibrary?: GQLArticleRequiredLibraryTypeResolver;
     FootNote?: GQLFootNoteTypeResolver;
+    AltText?: GQLAltTextTypeResolver;
+    ImageMetaInformation?: GQLImageMetaInformationTypeResolver;
     ImageLicense?: GQLImageLicenseTypeResolver;
     AudioLicense?: GQLAudioLicenseTypeResolver;
     BrightcoveIframe?: GQLBrightcoveIframeTypeResolver;
@@ -1148,7 +1166,7 @@ declare global {
   
   export interface GQLPodcastMetaTypeResolver<TParent = any> {
     introduction?: PodcastMetaToIntroductionResolver<TParent>;
-    coverPhoto?: PodcastMetaToCoverPhotoResolver<TParent>;
+    image?: PodcastMetaToImageResolver<TParent>;
     language?: PodcastMetaToLanguageResolver<TParent>;
   }
   
@@ -1156,7 +1174,7 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface PodcastMetaToCoverPhotoResolver<TParent = any, TResult = any> {
+  export interface PodcastMetaToImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -2174,6 +2192,87 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface GQLAltTextTypeResolver<TParent = any> {
+    alttext?: AltTextToAlttextResolver<TParent>;
+    language?: AltTextToLanguageResolver<TParent>;
+  }
+  
+  export interface AltTextToAlttextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface AltTextToLanguageResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLImageMetaInformationTypeResolver<TParent = any> {
+    id?: ImageMetaInformationToIdResolver<TParent>;
+    metaUrl?: ImageMetaInformationToMetaUrlResolver<TParent>;
+    title?: ImageMetaInformationToTitleResolver<TParent>;
+    alttext?: ImageMetaInformationToAlttextResolver<TParent>;
+    imageUrl?: ImageMetaInformationToImageUrlResolver<TParent>;
+    size?: ImageMetaInformationToSizeResolver<TParent>;
+    contentType?: ImageMetaInformationToContentTypeResolver<TParent>;
+    copyright?: ImageMetaInformationToCopyrightResolver<TParent>;
+    tags?: ImageMetaInformationToTagsResolver<TParent>;
+    caption?: ImageMetaInformationToCaptionResolver<TParent>;
+    supportedLanguages?: ImageMetaInformationToSupportedLanguagesResolver<TParent>;
+    created?: ImageMetaInformationToCreatedResolver<TParent>;
+    createdBy?: ImageMetaInformationToCreatedByResolver<TParent>;
+  }
+  
+  export interface ImageMetaInformationToIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToMetaUrlResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToTitleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToAlttextResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToImageUrlResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToSizeResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToContentTypeResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToCopyrightResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToTagsResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToCaptionResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToSupportedLanguagesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToCreatedResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ImageMetaInformationToCreatedByResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLImageLicenseTypeResolver<TParent = any> {
     title?: ImageLicenseToTitleResolver<TParent>;
     src?: ImageLicenseToSrcResolver<TParent>;
@@ -2257,7 +2356,6 @@ declare global {
     iframe?: BrightcoveLicenseToIframeResolver<TParent>;
     copyright?: BrightcoveLicenseToCopyrightResolver<TParent>;
     uploadDate?: BrightcoveLicenseToUploadDateResolver<TParent>;
-    copyText?: BrightcoveLicenseToCopyTextResolver<TParent>;
   }
   
   export interface BrightcoveLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -2292,16 +2390,11 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface BrightcoveLicenseToCopyTextResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
   export interface GQLH5pLicenseTypeResolver<TParent = any> {
     title?: H5pLicenseToTitleResolver<TParent>;
     src?: H5pLicenseToSrcResolver<TParent>;
     thumbnail?: H5pLicenseToThumbnailResolver<TParent>;
     copyright?: H5pLicenseToCopyrightResolver<TParent>;
-    copyText?: H5pLicenseToCopyTextResolver<TParent>;
   }
   
   export interface H5pLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -2317,10 +2410,6 @@ declare global {
   }
   
   export interface H5pLicenseToCopyrightResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface H5pLicenseToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -2356,7 +2445,6 @@ declare global {
     title?: ConceptLicenseToTitleResolver<TParent>;
     src?: ConceptLicenseToSrcResolver<TParent>;
     copyright?: ConceptLicenseToCopyrightResolver<TParent>;
-    copyText?: ConceptLicenseToCopyTextResolver<TParent>;
   }
   
   export interface ConceptLicenseToTitleResolver<TParent = any, TResult = any> {
@@ -2368,10 +2456,6 @@ declare global {
   }
   
   export interface ConceptLicenseToCopyrightResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface ConceptLicenseToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -3481,7 +3565,6 @@ declare global {
     download?: BrightcoveElementToDownloadResolver<TParent>;
     iframe?: BrightcoveElementToIframeResolver<TParent>;
     uploadDate?: BrightcoveElementToUploadDateResolver<TParent>;
-    copyText?: BrightcoveElementToCopyTextResolver<TParent>;
   }
   
   export interface BrightcoveElementToVideoidResolver<TParent = any, TResult = any> {
@@ -3524,14 +3607,9 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface BrightcoveElementToCopyTextResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
   export interface GQLH5pElementTypeResolver<TParent = any> {
     src?: H5pElementToSrcResolver<TParent>;
     thumbnail?: H5pElementToThumbnailResolver<TParent>;
-    copyText?: H5pElementToCopyTextResolver<TParent>;
   }
   
   export interface H5pElementToSrcResolver<TParent = any, TResult = any> {
@@ -3539,10 +3617,6 @@ declare global {
   }
   
   export interface H5pElementToThumbnailResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
-  export interface H5pElementToCopyTextResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import { IImageMetaInformationV2 } from '@ndla/types-image-api';
 import cheerio from 'cheerio';
 import { convertToSimpleImage, fetchImage } from '../api/imageApi';
 import { fetchOembed } from '../api/oembedApi';

--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import { IImageMetaInformationV2 } from '@ndla/types-image-api';
 import cheerio from 'cheerio';
 import { fetchOembed } from '../api/oembedApi';
 import { localConverter } from '../config';
@@ -12,7 +13,7 @@ import { fetch, resolveJson } from './apiHelpers';
 
 export async function fetchImage(imageId: string, context: Context) {
   const imageResponse = await fetch(`/image-api/v2/images/${imageId}`, context);
-  const image = await resolveJson(imageResponse);
+  const image: IImageMetaInformationV2 = await resolveJson(imageResponse);
   return {
     title: image.title.title,
     src: image.imageUrl,

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,11 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-frontpage-api/-/types-frontpage-api-0.0.3.tgz#31e6b1dba0b8a215c06b2918f34cfb0385192b0e"
   integrity sha512-1sAwf7TyjAElbzvWjfLw1PI4pG9HQ+KArMNY8shDZnY3GiASko2GsJUxbTX/ryU85iTwkA9dPPR+Zuo6C9o9DA==
 
+"@ndla/types-image-api@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@ndla/types-image-api/-/types-image-api-0.0.4.tgz#f5efe62b8cb97e857d07e4f967d246d71d1335c1"
+  integrity sha512-VTdQww63erpGg4tIysNxv1mvbIVMC6/mG5dEqL4xKJPmjgJGuGAoO2iJuBFOCR0m6NXAG7v9bk/qn1/pwPCEsw==
+
 "@ndla/types-learningpath-api@^0.0.2":
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/@ndla/types-learningpath-api/-/types-learningpath-api-0.0.2.tgz#6ae65f047ba8c7af32dd01ce800ec7254eee4e0e"


### PR DESCRIPTION
Henter utvidet bildedata fra image-api for podcasts. coverPhoto inneholder ikke nok data til å kunne vise lisens m.m.

Hva som er gjort:
- Lagt til imageApi.ts for henting av bilder fra image-api.
- resolver i podcastResolvers for å hente image og transformere objekter med language til string
- Lagt til ny bildetype i schema.ts for utvidet bilde-informasjon
- Fjernet copyText der det ikke er relevant lenger.