### PR TITLE
Hotfix. Correctly type podcast resolver

### DIFF
--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -9,6 +9,7 @@
 import {
   IAudioMetaInformation,
   IAudioSummarySearchResult,
+  IPodcastMeta,
 } from '@ndla/types-audio-api';
 import {
   fetchPodcast,
@@ -52,11 +53,11 @@ export const Query = {
 export const resolvers = {
   PodcastMeta: {
     async image(
-      audio: IAudioMetaInformation,
+      podcastMeta: IPodcastMeta,
       _: any,
       context: ContextWithLoaders,
     ): Promise<GQLImageMetaInformation | null> {
-      const id = audio.podcastMeta?.coverPhoto.id;
+      const id = podcastMeta?.coverPhoto.id;
       if (!id) {
         return null;
       }
@@ -65,6 +66,7 @@ export const resolvers = {
       if (!image) {
         return null;
       }
+
       return {
         ...image,
         title: image.title.title,


### PR DESCRIPTION
Fikser en feil i typingen av podcast resolver. Brukte feil interface og resolveren returnerte derfor null i stedet for et image.

Brukes kun i podcast-page PR i ndla-frontend, så dette påvirker ikke noe i prod.