### PR TITLE
Do not fetch concepts if empty list

### DIFF
--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -86,6 +86,9 @@ export const resolvers = {
       _: any,
       context: ContextWithLoaders,
     ): Promise<Concept[]> {
+      if (article?.conceptIds?.length === 0) {
+        return [];
+      }
       const results = await searchConcepts(
         { ids: article.conceptIds },
         context,

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -86,7 +86,7 @@ export const resolvers = {
       _: any,
       context: ContextWithLoaders,
     ): Promise<Concept[]> {
-      if (article?.conceptIds?.length > 0) {
+      if (article?.conceptIds && article.conceptIds.length > 0) {
         const results = await searchConcepts(
           { ids: article.conceptIds },
           context,

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -86,14 +86,14 @@ export const resolvers = {
       _: any,
       context: ContextWithLoaders,
     ): Promise<Concept[]> {
-      if (article?.conceptIds?.length === 0) {
-        return [];
+      if (article?.conceptIds?.length > 0) {
+        const results = await searchConcepts(
+          { ids: article.conceptIds },
+          context,
+        );
+        return results.concepts;
       }
-      const results = await searchConcepts(
-        { ids: article.conceptIds },
-        context,
-      );
-      return results.concepts;
+      return [];
     },
   },
 };


### PR DESCRIPTION
Fixes NDLANO/Issues#3036

Henter kun forklaringer dersom det er innhold i lista med ider. Ellers hentes alltid ti forklaringer. Kunne sikkert vore koda meir elegant.