### PR TITLE
3037 extended alert functionality

### DIFF
--- a/src/api/uptimeApi.ts
+++ b/src/api/uptimeApi.ts
@@ -12,16 +12,28 @@ import { ndlaEnvironment, uptimeOwner, uptimeRepo } from '../config';
 
 const baseUrl = 'https://api.github.com';
 
+interface GithubLabel {
+  name: string;
+}
+interface GithubIssue {
+  number: number;
+  title: string;
+  body: string;
+  labels?: GithubLabel[];
+}
+
 export async function fetchUptimeIssues(
   context: ContextWithLoaders,
 ): Promise<GQLUptimeAlert[]> {
   const path = `${baseUrl}/repos/${uptimeOwner}/${uptimeRepo}/issues?state=open&labels=maintenance,${ndlaEnvironment}`;
   const response = await fetch(path, context, { timeout: 3000 });
-  const issues: GQLUptimeAlert[] = await resolveJson(response);
+  const issues: GithubIssue[] = await resolveJson(response);
 
   return issues.map(issue => {
     return {
       title: issue.title,
+      number: issue.number,
+      closable: !issue.labels?.find(label => label.name === 'permanent'),
       body: he.decode(issue.body).replace(/<[^>]*>?/gm, ''),
     };
   });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -847,15 +847,11 @@ export const typeDefs = gql`
     learningResources: FrontPageResources!
   }
 
-  type GithubLabel {
-    name: String!
-  }
-
   type UptimeAlert {
     title: String!
     body: String
     number: Int!
-    labels: [GithubLabel!]
+    closable: Boolean!
   }
 
   type Query {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -847,9 +847,15 @@ export const typeDefs = gql`
     learningResources: FrontPageResources!
   }
 
+  type GithubLabel {
+    name: String!
+  }
+
   type UptimeAlert {
     title: String!
     body: String
+    number: Int!
+    labels: [GithubLabel!]
   }
 
   type Query {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -905,15 +905,11 @@ declare global {
     learningResources: GQLFrontPageResources;
   }
   
-  export interface GQLGithubLabel {
-    name: string;
-  }
-  
   export interface GQLUptimeAlert {
     title: string;
     body?: string;
     number: number;
-    labels?: Array<GQLGithubLabel>;
+    closable: boolean;
   }
   
   export interface GQLQuery {
@@ -1068,7 +1064,6 @@ declare global {
     GroupSearch?: GQLGroupSearchTypeResolver;
     FrontPageResources?: GQLFrontPageResourcesTypeResolver;
     FrontpageSearch?: GQLFrontpageSearchTypeResolver;
-    GithubLabel?: GQLGithubLabelTypeResolver;
     UptimeAlert?: GQLUptimeAlertTypeResolver;
     Query?: GQLQueryTypeResolver;
   }
@@ -3962,19 +3957,11 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface GQLGithubLabelTypeResolver<TParent = any> {
-    name?: GithubLabelToNameResolver<TParent>;
-  }
-  
-  export interface GithubLabelToNameResolver<TParent = any, TResult = any> {
-    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
-  }
-  
   export interface GQLUptimeAlertTypeResolver<TParent = any> {
     title?: UptimeAlertToTitleResolver<TParent>;
     body?: UptimeAlertToBodyResolver<TParent>;
     number?: UptimeAlertToNumberResolver<TParent>;
-    labels?: UptimeAlertToLabelsResolver<TParent>;
+    closable?: UptimeAlertToClosableResolver<TParent>;
   }
   
   export interface UptimeAlertToTitleResolver<TParent = any, TResult = any> {
@@ -3989,7 +3976,7 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface UptimeAlertToLabelsResolver<TParent = any, TResult = any> {
+  export interface UptimeAlertToClosableResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -905,9 +905,15 @@ declare global {
     learningResources: GQLFrontPageResources;
   }
   
+  export interface GQLGithubLabel {
+    name: string;
+  }
+  
   export interface GQLUptimeAlert {
     title: string;
     body?: string;
+    number: number;
+    labels?: Array<GQLGithubLabel>;
   }
   
   export interface GQLQuery {
@@ -1062,6 +1068,7 @@ declare global {
     GroupSearch?: GQLGroupSearchTypeResolver;
     FrontPageResources?: GQLFrontPageResourcesTypeResolver;
     FrontpageSearch?: GQLFrontpageSearchTypeResolver;
+    GithubLabel?: GQLGithubLabelTypeResolver;
     UptimeAlert?: GQLUptimeAlertTypeResolver;
     Query?: GQLQueryTypeResolver;
   }
@@ -3955,9 +3962,19 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
+  export interface GQLGithubLabelTypeResolver<TParent = any> {
+    name?: GithubLabelToNameResolver<TParent>;
+  }
+  
+  export interface GithubLabelToNameResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
   export interface GQLUptimeAlertTypeResolver<TParent = any> {
     title?: UptimeAlertToTitleResolver<TParent>;
     body?: UptimeAlertToBodyResolver<TParent>;
+    number?: UptimeAlertToNumberResolver<TParent>;
+    labels?: UptimeAlertToLabelsResolver<TParent>;
   }
   
   export interface UptimeAlertToTitleResolver<TParent = any, TResult = any> {
@@ -3965,6 +3982,14 @@ declare global {
   }
   
   export interface UptimeAlertToBodyResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface UptimeAlertToNumberResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface UptimeAlertToLabelsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
Relatert til NDLANO/Issues#3037

Legger til utvidet informasjon for alerts fra github. Returnerer nå følgende felter i graphql:
- number: Nummer på issue. Skal brukes til å huske om en bruker har lukket banneret.
- closable: En sjekk om issuet har tag "permanent". Dersomd en ikke har permanent kan den lukkes.