### PR TITLE
Passes through versionhash header from frontend to apis.

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -42,6 +42,7 @@ declare global {
     res: Response;
     token?: AuthToken;
     feideAuthorization?: string;
+    versionHash?: string;
     language: string;
     shouldUseCache: boolean;
     taxonomyUrl: string;

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -46,12 +46,17 @@ async function fetchHelper(
     ? { feideAuthorization: context.feideAuthorization }
     : null;
 
+  const versionHash = context.versionHash
+    ? { versionhash: context.versionHash }
+    : null;
+
   const cacheHeaders = !context.shouldUseCache
     ? { 'Cache-Control': 'no-cache' }
     : {};
 
   const headers = {
     ...feideAuthorization,
+    ...versionHash,
     ...accessTokenAuth,
     ...cacheHeaders,
   };


### PR DESCRIPTION
Første steg i å kunne åpne ndla.no for en gitt taksonomiversjon.
Neste blir å lage en provider i ndla-frontend som kan settes ved å kalle feks ndla.no?version=hash