### PR TITLE
Vi sender visst 'default' som default så derfor må vi sjekke at heade…

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,8 @@ function getShouldUseCache(request: Request): boolean {
 
   const cacheControlDisable = disableCacheHeaders.includes(cacheControl);
   const feideHeaderPresent = !!feideAuthHeader;
-  const versionHashPresent = !!versionHashHeader && versionHashHeader !== 'default';
+  const versionHashPresent =
+    !!versionHashHeader && versionHashHeader !== 'default';
 
   return !cacheControlDisable && !feideHeaderPresent && !versionHashPresent;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -69,7 +69,7 @@ function getShouldUseCache(request: Request): boolean {
 
   const cacheControlDisable = disableCacheHeaders.includes(cacheControl);
   const feideHeaderPresent = !!feideAuthHeader;
-  const versionHashPresent = !!versionHashHeader;
+  const versionHashPresent = !!versionHashHeader && versionHashHeader !== 'default';
 
   return !cacheControlDisable && !feideHeaderPresent && !versionHashPresent;
 }


### PR DESCRIPTION
…r som sendes != default.

Innsåg ikkje at det at vi har spesifisert å alltid sende versionhash i ndla-frontend med verdien 'default' trigga det slik at cache ignoreres. Har oppdatert sjekken slik at cache brukes dersom header != default.