### PR TITLE
Use /repos endpoint in local api-gateway

### DIFF
--- a/src/api/uptimeApi.ts
+++ b/src/api/uptimeApi.ts
@@ -15,8 +15,6 @@ import {
   uptimeToken,
 } from '../config';
 
-const baseUrl = 'https://api.github.com';
-
 interface GithubLabel {
   name: string;
 }
@@ -30,7 +28,7 @@ interface GithubIssue {
 export async function fetchUptimeIssues(
   context: ContextWithLoaders,
 ): Promise<GQLUptimeAlert[]> {
-  const path = `${baseUrl}/repos/${uptimeOwner}/${uptimeRepo}/issues?state=open&labels=maintenance,${ndlaEnvironment}`;
+  const path = `/repos/${uptimeOwner}/${uptimeRepo}/issues?state=open&labels=maintenance,${ndlaEnvironment}`;
   const githubAuth = uptimeToken
     ? { Authorization: `Bearer ${uptimeToken}` }
     : null;


### PR DESCRIPTION
Fixes NDLANO/Issues#3114

Depends on https://github.com/NDLANO/deploy/pull/403

Bruker endepunkt i api-gateway for å innføre cache på kall til oppetid.