### PR TITLE
Adds missing handling of visual element for article-page.

### DIFF
--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -19,7 +19,7 @@ import { Concept } from '../api/conceptApi';
 export const Query = {
   async article(
     _: any,
-    { id, subjectId, isOembed, path }: QueryToArticleArgs,
+    { id, subjectId, isOembed, path, showVisualElement }: QueryToArticleArgs,
     context: ContextWithLoaders,
   ): Promise<GQLArticle> {
     return fetchArticle(
@@ -28,6 +28,7 @@ export const Query = {
         subjectId,
         isOembed,
         path,
+        showVisualElement,
       },
       context,
     );


### PR DESCRIPTION
NDLANO/Issues#3123

Dette har berre mangla hittil. Parameteret brukes for case i tverrfaglig tema, men om du ser emneartikkel via lti så vises ikkje visuelt element fordi parameteret aldri sendes til article-converter.