### PR TITLE
Rename parentTopics to parents. Not used anywhere anyhow.

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -82,7 +82,7 @@ export async function fetchResource(
   let rank;
   let relevanceId;
   if (topicId) {
-    const parent = resource.parentTopics.find(topic => topic.id === topicId);
+    const parent = resource.parents.find(topic => topic.id === topicId);
     rank = parent?.rank;
     relevanceId = parent?.relevanceId || 'urn:relevance:core';
   }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -284,7 +284,7 @@ export const typeDefs = gql`
     article(subjectId: String, isOembed: String): Article
     availability: String
     resourceTypes: [ResourceType!]
-    parentTopics: [Topic!]
+    parents: [Topic!]
     breadcrumbs: [[String!]!]
     supportedLanguages: [String!]!
   }

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -331,7 +331,7 @@ declare global {
     article?: GQLArticle;
     availability?: string;
     resourceTypes?: Array<GQLResourceType>;
-    parentTopics?: Array<GQLTopic>;
+    parents?: Array<GQLTopic>;
     breadcrumbs?: Array<Array<string>>;
     supportedLanguages: Array<string>;
   }
@@ -507,6 +507,7 @@ declare global {
     concepts?: Array<GQLConcept>;
     relatedContent?: Array<GQLRelatedContent>;
     availability?: string;
+    revisionDate?: string;
   }
   
   export interface GQLembedVisualelement {
@@ -1874,7 +1875,7 @@ declare global {
     article?: ResourceToArticleResolver<TParent>;
     availability?: ResourceToAvailabilityResolver<TParent>;
     resourceTypes?: ResourceToResourceTypesResolver<TParent>;
-    parentTopics?: ResourceToParentTopicsResolver<TParent>;
+    parents?: ResourceToParentsResolver<TParent>;
     breadcrumbs?: ResourceToBreadcrumbsResolver<TParent>;
     supportedLanguages?: ResourceToSupportedLanguagesResolver<TParent>;
   }
@@ -1935,7 +1936,7 @@ declare global {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface ResourceToParentTopicsResolver<TParent = any, TResult = any> {
+  export interface ResourceToParentsResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
@@ -2508,6 +2509,7 @@ declare global {
     concepts?: ArticleToConceptsResolver<TParent>;
     relatedContent?: ArticleToRelatedContentResolver<TParent>;
     availability?: ArticleToAvailabilityResolver<TParent>;
+    revisionDate?: ArticleToRevisionDateResolver<TParent>;
   }
   
   export interface ArticleToIdResolver<TParent = any, TResult = any> {
@@ -2618,6 +2620,10 @@ declare global {
   }
   
   export interface ArticleToAvailabilityResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface ArticleToRevisionDateResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
I taksonomi blei det i forbindelse med node-struktur endra fra parentTopics til parents, men med et alias for at nettopp denne koden skulle fungere. Lista parentTopics brukes kun i graphql-api så det skal ikkje være farlig å endre.