### PR TITLE
#3190: Adds support for fallback to audio-api searches

### DIFF
--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -35,9 +35,10 @@ export async function fetchPodcastsPage(
   context: Context,
   pageSize: number,
   page: number,
+  fallback: boolean,
 ): Promise<IAudioSummarySearchResult> {
   const response = await fetch(
-    `/audio-api/v1/audio/?page-size=${pageSize}&page=${page}&audio-type=podcast&language=${context.language}`,
+    `/audio-api/v1/audio/?page-size=${pageSize}&page=${page}&audio-type=podcast&language=${context.language}&fallback=${fallback}`,
     context,
   );
   return await resolveJson(response);
@@ -58,9 +59,10 @@ export async function fetchPodcastSeriesPage(
   context: Context,
   pageSize: number,
   page: number,
+  fallback: boolean,
 ): Promise<IAudioSummarySearchResult> {
   const response = await fetch(
-    `/audio-api/v1/series/?page-size=${pageSize}&page=${page}&language=${context.language}`,
+    `/audio-api/v1/series/?page-size=${pageSize}&page=${page}&language=${context.language}&fallback=${fallback}`,
     context,
   );
   return await resolveJson(response);

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -29,10 +29,10 @@ export const Query = {
   },
   async podcastSearch(
     _: any,
-    { pageSize, page }: QueryToPodcastSearchArgs,
+    { pageSize, page, fallback }: QueryToPodcastSearchArgs,
     context: ContextWithLoaders,
   ): Promise<IAudioSummarySearchResult> {
-    return fetchPodcastsPage(context, pageSize, page);
+    return fetchPodcastsPage(context, pageSize, page, fallback);
   },
   async podcastSeries(
     _: any,
@@ -43,10 +43,10 @@ export const Query = {
   },
   async podcastSeriesSearch(
     _: any,
-    { pageSize, page }: QueryToPodcastSeriesSearchArgs,
+    { pageSize, page, fallback }: QueryToPodcastSeriesSearchArgs,
     context: ContextWithLoaders,
   ): Promise<IAudioSummarySearchResult> {
-    return fetchPodcastSeriesPage(context, pageSize, page);
+    return fetchPodcastSeriesPage(context, pageSize, page, fallback);
   },
 };
 

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -32,7 +32,7 @@ export const Query = {
     { pageSize, page, fallback }: QueryToPodcastSearchArgs,
     context: ContextWithLoaders,
   ): Promise<IAudioSummarySearchResult> {
-    return fetchPodcastsPage(context, pageSize, page, fallback);
+    return fetchPodcastsPage(context, pageSize, page, fallback ?? false);
   },
   async podcastSeries(
     _: any,
@@ -46,7 +46,7 @@ export const Query = {
     { pageSize, page, fallback }: QueryToPodcastSeriesSearchArgs,
     context: ContextWithLoaders,
   ): Promise<IAudioSummarySearchResult> {
-    return fetchPodcastSeriesPage(context, pageSize, page, fallback);
+    return fetchPodcastSeriesPage(context, pageSize, page, fallback ?? false);
   },
 };
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1011,9 +1011,13 @@ export const typeDefs = gql`
       relevance: String
     ): SearchWithoutPagination
     podcast(id: Int!): AudioWithSeries
-    podcastSearch(page: Int!, pageSize: Int!): AudioSearch
+    podcastSearch(page: Int!, pageSize: Int!, fallback: Boolean): AudioSearch
     podcastSeries(id: Int!): PodcastSeriesWithEpisodes
-    podcastSeriesSearch(page: Int!, pageSize: Int!): PodcastSeriesSearch
+    podcastSeriesSearch(
+      page: Int!
+      pageSize: Int!
+      fallback: Boolean
+    ): PodcastSeriesSearch
     alerts: [UptimeAlert]
     folders(includeSubfolders: Boolean, includeResources: Boolean): [Folder!]!
     folderResourceMeta(

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -4518,6 +4518,7 @@ declare global {
   export interface QueryToPodcastSearchArgs {
     page: number;
     pageSize: number;
+    fallback?: boolean;
   }
   export interface QueryToPodcastSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
@@ -4533,6 +4534,7 @@ declare global {
   export interface QueryToPodcastSeriesSearchArgs {
     page: number;
     pageSize: number;
+    fallback?: boolean;
   }
   export interface QueryToPodcastSeriesSearchResolver<TParent = any, TResult = any> {
     (parent: TParent, args: QueryToPodcastSeriesSearchArgs, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;


### PR DESCRIPTION
Relates to NDLANO/Issues#3190

Kan testes ved å sjekke at `fallback` parameteret sendes videre til audio-api :smile: 