### PR TITLE
Returns valid path from search.

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -18,6 +18,7 @@ interface GroupSearchJSON {
 }
 
 interface ContentTypeJSON {
+  id: number;
   paths: [string];
   url: string;
   title: {
@@ -31,6 +32,7 @@ interface ContentTypeJSON {
     alt: string;
   };
   contexts: GQLSearchContext;
+  learningResourceType: string;
 }
 
 interface SearchResultContexts {
@@ -102,9 +104,15 @@ export async function groupSearch(
               p => p.split('/')[1] === subjects[0].replace('urn:', ''),
             )
           : contentTypeResult.paths?.[0];
+      const isLearningpath =
+        contentTypeResult.learningResourceType === 'learningpath';
       return {
         ...contentTypeResult,
-        path: path || contentTypeResult.url,
+        path:
+          path ||
+          (isLearningpath
+            ? `/learningpaths/${contentTypeResult.id}`
+            : `/article/${contentTypeResult.id}`),
         name: contentTypeResult.title.title,
         ingress: contentTypeResult.metaDescription.metaDescription,
         contexts: contentTypeResult.contexts,


### PR DESCRIPTION
Fikser et problem der emner uten kontekst ikkje lar seg embedde fra lti-sida.

Feilen kan testes først på test.ndla.no/lti der du søker på ordet test. For det første treffet fungerer det ikkje å klikke på Sett inn fordi path fra søket sendes til /oembed-endepunktet, og då blir urlen som kalles https://test.ndla.no/oembed?url=https://test.ndla.nohttps://api.test.ndla.no/article-api/v2/articles/20086 og den feiler fordi vi ikkje kjenner igjen pathen.

Ved å returnere en gyldig path for disse emnene så vil urlen som kalles bli https://test.ndla.no/oembed?url=https://test.ndla.no/article/20086 og den klarer vi å håndtere.

Testes sammen med lokal ndla-frontend.