### PR TITLE
Reintroduce removed resourceTypes parameter

### DIFF
--- a/src/api/folderResourceMetaApi.ts
+++ b/src/api/folderResourceMetaApi.ts
@@ -70,6 +70,7 @@ const fetchAndTransformArticleMeta = async (
       fallback: 'true',
       // @ts-ignore ids are not parameterized correctly
       ids: resources.map(r => r.id).join(','),
+      resourceTypes: resourceTypes.join(','),
     },
     context,
   );


### PR DESCRIPTION
Vet ikke hvorfor eller hvordan jeg klarte å fjerne dette, men det skal så absolutt være der.