### PR TITLE
Separating foldermeta for article and learningpath

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -107,4 +107,15 @@ export const resolvers: GQLResolver = {
       return 'ArticleSearchResult';
     },
   },
+  FolderResourceMeta: {
+    // Resolves FolderResourceMeta interface
+    __resolveType(
+      folderResourceMeta: any,
+    ): GQLPossibleFolderResourceMetaTypeNames {
+      if (folderResourceMeta.type === 'learningpath') {
+        return 'LearningpathFolderResourceMeta';
+      }
+      return 'ArticleFolderResourceMeta';
+    },
+  },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -899,7 +899,25 @@ export const typeDefs = gql`
     name: String!
   }
 
-  type FolderResourceMeta {
+  interface FolderResourceMeta {
+    id: Int!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type ArticleFolderResourceMeta implements FolderResourceMeta {
+    id: Int!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type LearningpathFolderResourceMeta implements FolderResourceMeta {
     id: Int!
     type: String!
     resourceTypes: [FolderResourceResourceType!]!

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -966,6 +966,35 @@ declare global {
     description: string;
   }
   
+  /** Use this to resolve interface type FolderResourceMeta */
+  export type GQLPossibleFolderResourceMetaTypeNames =
+  'ArticleFolderResourceMeta' |
+  'LearningpathFolderResourceMeta';
+  
+  export interface GQLFolderResourceMetaNameMap {
+    FolderResourceMeta: GQLFolderResourceMeta;
+    ArticleFolderResourceMeta: GQLArticleFolderResourceMeta;
+    LearningpathFolderResourceMeta: GQLLearningpathFolderResourceMeta;
+  }
+  
+  export interface GQLArticleFolderResourceMeta extends GQLFolderResourceMeta {
+    id: number;
+    type: string;
+    resourceTypes: Array<GQLFolderResourceResourceType>;
+    metaImage?: GQLMetaImage;
+    title: string;
+    description: string;
+  }
+  
+  export interface GQLLearningpathFolderResourceMeta extends GQLFolderResourceMeta {
+    id: number;
+    type: string;
+    resourceTypes: Array<GQLFolderResourceResourceType>;
+    metaImage?: GQLMetaImage;
+    title: string;
+    description: string;
+  }
+  
   export interface GQLNewFolder {
     name: string;
     parentId?: string;
@@ -1167,7 +1196,12 @@ declare global {
     Folder?: GQLFolderTypeResolver;
     FolderResource?: GQLFolderResourceTypeResolver;
     FolderResourceResourceType?: GQLFolderResourceResourceTypeTypeResolver;
-    FolderResourceMeta?: GQLFolderResourceMetaTypeResolver;
+    FolderResourceMeta?: {
+      __resolveType: GQLFolderResourceMetaTypeResolver
+    };
+    
+    ArticleFolderResourceMeta?: GQLArticleFolderResourceMetaTypeResolver;
+    LearningpathFolderResourceMeta?: GQLLearningpathFolderResourceMetaTypeResolver;
     NewFolder?: GQLNewFolderTypeResolver;
     NewFolderResource?: GQLNewFolderResourceTypeResolver;
     UpdatedFolder?: GQLUpdatedFolderTypeResolver;
@@ -4225,35 +4259,71 @@ declare global {
   }
   
   export interface GQLFolderResourceMetaTypeResolver<TParent = any> {
-    id?: FolderResourceMetaToIdResolver<TParent>;
-    type?: FolderResourceMetaToTypeResolver<TParent>;
-    resourceTypes?: FolderResourceMetaToResourceTypesResolver<TParent>;
-    metaImage?: FolderResourceMetaToMetaImageResolver<TParent>;
-    title?: FolderResourceMetaToTitleResolver<TParent>;
-    description?: FolderResourceMetaToDescriptionResolver<TParent>;
+    (parent: TParent, context: any, info: GraphQLResolveInfo): 'ArticleFolderResourceMeta' | 'LearningpathFolderResourceMeta' | Promise<'ArticleFolderResourceMeta' | 'LearningpathFolderResourceMeta'>;
+  }
+  export interface GQLArticleFolderResourceMetaTypeResolver<TParent = any> {
+    id?: ArticleFolderResourceMetaToIdResolver<TParent>;
+    type?: ArticleFolderResourceMetaToTypeResolver<TParent>;
+    resourceTypes?: ArticleFolderResourceMetaToResourceTypesResolver<TParent>;
+    metaImage?: ArticleFolderResourceMetaToMetaImageResolver<TParent>;
+    title?: ArticleFolderResourceMetaToTitleResolver<TParent>;
+    description?: ArticleFolderResourceMetaToDescriptionResolver<TParent>;
   }
   
-  export interface FolderResourceMetaToIdResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToIdResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FolderResourceMetaToTypeResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToTypeResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FolderResourceMetaToResourceTypesResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToResourceTypesResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FolderResourceMetaToMetaImageResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToMetaImageResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FolderResourceMetaToTitleResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToTitleResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   
-  export interface FolderResourceMetaToDescriptionResolver<TParent = any, TResult = any> {
+  export interface ArticleFolderResourceMetaToDescriptionResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface GQLLearningpathFolderResourceMetaTypeResolver<TParent = any> {
+    id?: LearningpathFolderResourceMetaToIdResolver<TParent>;
+    type?: LearningpathFolderResourceMetaToTypeResolver<TParent>;
+    resourceTypes?: LearningpathFolderResourceMetaToResourceTypesResolver<TParent>;
+    metaImage?: LearningpathFolderResourceMetaToMetaImageResolver<TParent>;
+    title?: LearningpathFolderResourceMetaToTitleResolver<TParent>;
+    description?: LearningpathFolderResourceMetaToDescriptionResolver<TParent>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToIdResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToTypeResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToResourceTypesResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToMetaImageResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToTitleResolver<TParent = any, TResult = any> {
+    (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
+  }
+  
+  export interface LearningpathFolderResourceMetaToDescriptionResolver<TParent = any, TResult = any> {
     (parent: TParent, args: {}, context: any, info: GraphQLResolveInfo): TResult | Promise<TResult>;
   }
   


### PR DESCRIPTION
Forhindrer at foldermeta for artikler også brukes for læringsstier, ved at vi skiller på disse. Dette må gjøres fordi graphql cacher første treff av en gitt type med en gitt id, og når article og learningpath har samme type og samme id, vil den første som hentes vinne.

Må testes sammen med pr i ndla-frontend.

Test:
* Hent foldermeta for artikkel og læringssti som deler id:
* Læringssti id 3: /subject:1:01c27030-e8f8-4a7c-a5b3-489fdb8fea30/topic:2:182849/topic:2:175043/resource:1:176514 
* Artikkel id 3: /subject:1:19dae192-699d-488f-8218-d81535ce3ae3/topic:2:179373/topic:2:170165/resource:1:124037 