### PR TITLE
Filtrerer ut sletta artikler fra filmforside.

### DIFF
--- a/src/resolvers/frontpageResolvers.ts
+++ b/src/resolvers/frontpageResolvers.ts
@@ -11,6 +11,7 @@ import {
   ISubjectPageData,
   IFilmFrontPageData,
   ISubjectCollection,
+  IMovieTheme,
 } from '@ndla/types-frontpage-api';
 import {
   fetchResource,
@@ -21,6 +22,7 @@ import {
   fetchMovieMeta,
   queryResourcesOnContentURI,
 } from '../api';
+import { getArticleIdFromUrn } from '../utils/articleHelpers';
 import {
   GQLMetaImage,
   GQLMoviePath,
@@ -92,6 +94,24 @@ export const resolvers = {
         category.subjects.find(categorySubject => {
           return categorySubject.id === subject.id;
         }),
+      );
+    },
+  },
+
+  MovieTheme: {
+    async movies(
+      theme: IMovieTheme,
+      _: any,
+      context: ContextWithLoaders,
+    ): Promise<string[]> {
+      const articles = await context.loaders.articlesLoader.loadMany(
+        theme.movies.map(movie => getArticleIdFromUrn(movie)),
+      );
+      const nonNullArticles = articles.filter(article => !!article);
+      return theme.movies.filter(movie =>
+        nonNullArticles.find(
+          article => `${article.id}` === getArticleIdFromUrn(movie),
+        ),
       );
     },
   },


### PR DESCRIPTION
Artikler som er sletta gjør at henting av filmforside feiler med feil i path ["filmfrontpage", "movieThemes", 2, "movies", 5, "title"]

Dette er fordi artikkelen på plass 5 i theme på plass 2 er sletta. Denne pr filterer movies i themene slik at sletta artikler ikkje lenger tas med.