### PR TITLE
Adding error handing of competencegoalsetfetching

### DIFF
--- a/src/api/curriculumApi.ts
+++ b/src/api/curriculumApi.ts
@@ -242,23 +242,14 @@ export async function fetchLK20CompetenceGoalSet(
   code: string,
   context: Context,
 ): Promise<string[]> {
-  return Promise.resolve(
-    curriculumFetch(
-      `/grep/kl06/v201906/kompetansemaalsett-lk20/${code}`,
-      context,
-    ),
-  )
-    .then(async response => {
-      const json: CompetenceGoalSet = await resolveJson(response);
-      return Promise.all(json?.kompetansemaal?.map(km => km.kode));
-    })
-    .catch(reason => {
-      console.error(
-        `Something went wrong when fetching competence goal set, with code: '${code}':\n`,
-        reason,
-      );
-      return [];
-    });
+  const response = await curriculumFetch(
+    `/grep/kl06/v201906/kompetansemaalsett-lk20/${code}`,
+    context,
+  );
+  // Handle timeout events
+  const json: CompetenceGoalSet = await resolveJson(response, {});
+  const promises = json?.kompetansemaal?.map(km => km.kode) || [];
+  return Promise.all(promises);
 }
 
 export async function fetchCoreElement(

--- a/src/api/curriculumApi.ts
+++ b/src/api/curriculumApi.ts
@@ -242,12 +242,23 @@ export async function fetchLK20CompetenceGoalSet(
   code: string,
   context: Context,
 ): Promise<string[]> {
-  const response = await curriculumFetch(
-    `/grep/kl06/v201906/kompetansemaalsett-lk20/${code}`,
-    context,
-  );
-  const json: CompetenceGoalSet = await resolveJson(response);
-  return Promise.all(json.kompetansemaal.map(km => km.kode));
+  return Promise.resolve(
+    curriculumFetch(
+      `/grep/kl06/v201906/kompetansemaalsett-lk20/${code}`,
+      context,
+    ),
+  )
+    .then(async response => {
+      const json: CompetenceGoalSet = await resolveJson(response);
+      return Promise.all(json?.kompetansemaal?.map(km => km.kode));
+    })
+    .catch(reason => {
+      console.error(
+        `Something went wrong when fetching competence goal set, with code: '${code}':\n`,
+        reason,
+      );
+      return [];
+    });
 }
 
 export async function fetchCoreElement(

--- a/src/api/curriculumApi.ts
+++ b/src/api/curriculumApi.ts
@@ -246,7 +246,7 @@ export async function fetchLK20CompetenceGoalSet(
     `/grep/kl06/v201906/kompetansemaalsett-lk20/${code}`,
     context,
   );
-  // Handle timeout events
+  // Fallback to empty object in case of timeout or 404
   const json: CompetenceGoalSet = await resolveJson(response, {});
   const promises = json?.kompetansemaal?.map(km => km.kode) || [];
   return Promise.all(promises);

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -83,7 +83,10 @@ export async function resolveNothingFromStatus(
   throw Object.assign(new Error(message), { status });
 }
 
-export async function resolveJson(response: Response): Promise<any> {
+export async function resolveJson(
+  response: Response,
+  fallback?: any,
+): Promise<any> {
   const { status, ok, url, statusText } = response;
 
   if (status === 204) {
@@ -97,6 +100,10 @@ export async function resolveJson(response: Response): Promise<any> {
   }
 
   const message = `Api call to ${url} failed with status ${status} ${statusText}`;
+  if (fallback) {
+    console.error(message);
+    return fallback;
+  }
   throw Object.assign(new Error(message), { status, json });
 }
 


### PR DESCRIPTION
Dersom henting av kompetansemålsett tar lenger tid enn 3 sekund så feiler kallet, og fordi graphql så vil subject som returneres være null, og du får side som krasher.