### PR TITLE
Include json and status for errors

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -137,8 +137,7 @@ async function startApolloServer() {
         message: err.message,
         locations: err.locations,
         path: err.path,
-        status: err.originalError && err.originalError.status,
-        json: err.originalError && err.originalError.json,
+        extensions: err?.extensions,
       };
     },
   });

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -8,6 +8,7 @@
  */
 
 import { Response } from 'node-fetch';
+import { GraphQLError } from 'graphql';
 import { apiUrl } from '../config';
 import createFetch from './fetch';
 import { createCache } from '../cache';
@@ -80,7 +81,7 @@ export async function resolveNothingFromStatus(
   }
 
   const message = `Api call to ${url} failed with status ${status} ${statusText}`;
-  throw Object.assign(new Error(message), { status });
+  throw new GraphQLError(message, { extensions: { status } });
 }
 
 export async function resolveJson(
@@ -104,7 +105,7 @@ export async function resolveJson(
     console.error(message);
     return fallback;
   }
-  throw Object.assign(new Error(message), { status, json });
+  throw new GraphQLError(message, { extensions: { status, json } });
 }
 
 // converting h5p object from externals to graphQL schema type (Copyright-type)


### PR DESCRIPTION
Feltene er tilgjengelig under `error.extensions` dersom de finnes. Tenkte å bruke det til å filtrere ut 404-feil fra f.eks taksonomi, slik at vi ikke fyller loggly med det. Tanker?