### PR TITLE
3380 video page

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -48,3 +48,4 @@ export {
 export { fetchOembed } from './oembedApi';
 export { searchConcepts, fetchConcept, fetchListingPage } from './conceptApi';
 export { fetchUptimeIssues } from './uptimeApi';
+export { fetchBrightcoveVideo } from './videoApi';

--- a/src/api/videoApi.ts
+++ b/src/api/videoApi.ts
@@ -71,6 +71,7 @@ export async function fetchBrightcoveVideo(
         license: brightcoveVideo.custom_fields.license,
         accountId: accountId,
       },
+      name: brightcoveVideo.name,
     };
   } catch (e) {
     return null;
@@ -106,4 +107,5 @@ export interface BrightcoveVideoSource {
 export interface BrightcoveApiType {
   account_id?: string | null;
   custom_fields: Record<string, string>;
+  name?: string;
 }

--- a/src/api/videoApi.ts
+++ b/src/api/videoApi.ts
@@ -22,10 +22,10 @@ const b64EncodeUnicode = (str: string) =>
 const brightcoveTokenUrl = 'https://oauth.brightcove.com/v3/access_token';
 const brightcoveApiUrl = 'https://cms.api.brightcove.com';
 const clientIdSecret = `${getEnvironmentVariabel(
-  'BRIGHTCOVE_API_CLIENT_ID', // TODO lagre frontend
-)}:${getEnvironmentVariabel('BRIGHTCOVE_API_CLIENT_SECRET')}`; // TODO Lagre frontend
+  'BRIGHTCOVE_API_CLIENT_ID',
+)}:${getEnvironmentVariabel('BRIGHTCOVE_API_CLIENT_SECRET')}`;
 
-const accountId = getEnvironmentVariabel('BRIGHTCOVE_ACCOUNT_ID', '123456789'); // TODO Lagre i graphql
+const accountId = getEnvironmentVariabel('BRIGHTCOVE_ACCOUNT_ID', '123456789');
 
 export async function fetchBrightcoveVideo(
   id: string,
@@ -36,8 +36,8 @@ export async function fetchBrightcoveVideo(
     const brightcoveSourceUrl = `${brightcoveVideoUrl}/sources`;
 
     const [responseVideo, responseSource] = await Promise.all([
-      fetchWithBrightCoveToken(brightcoveVideoUrl, context),
-      fetchWithBrightCoveToken(brightcoveSourceUrl, context),
+      fetchWithBrightcoveToken(brightcoveVideoUrl, context),
+      fetchWithBrightcoveToken(brightcoveSourceUrl, context),
     ]);
     const brightcoveVideo: BrightcoveApiType = await resolveJson(responseVideo);
     const brightcoveSources: BrightcoveVideoSource[] = await resolveJson(
@@ -77,7 +77,7 @@ export async function fetchBrightcoveVideo(
   }
 }
 
-export const fetchWithBrightCoveToken = async (
+export const fetchWithBrightcoveToken = async (
   url: string,
   context: Context,
 ) => {

--- a/src/api/videoApi.ts
+++ b/src/api/videoApi.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { GQLBrightcoveElement } from 'schema';
+import sortBy from 'lodash/sortBy';
+import { getEnvironmentVariabel } from '../config';
+import { resolveJson } from '../utils/apiHelpers';
+import { fetch } from '../utils/apiHelpers';
+
+const b64EncodeUnicode = (str: string) =>
+  btoa(
+    encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, p1) =>
+      String.fromCharCode(Number(`0x${p1}`)),
+    ),
+  );
+
+const brightcoveTokenUrl = 'https://oauth.brightcove.com/v3/access_token';
+const brightcoveApiUrl = 'https://cms.api.brightcove.com';
+const clientIdSecret = `${getEnvironmentVariabel(
+  'BRIGHTCOVE_API_CLIENT_ID', // TODO lagre frontend
+)}:${getEnvironmentVariabel('BRIGHTCOVE_API_CLIENT_SECRET')}`; // TODO Lagre frontend
+
+const accountId = getEnvironmentVariabel('BRIGHTCOVE_ACCOUNT_ID', '123456789'); // TODO Lagre i graphql
+
+export async function fetchBrightcoveVideo(
+  id: string,
+  context: Context,
+): Promise<GQLBrightcoveElement | null> {
+  try {
+    const brightcoveVideoUrl = `${brightcoveApiUrl}/v1/accounts/${accountId}/videos/${id}`;
+    const brightcoveSourceUrl = `${brightcoveVideoUrl}/sources`;
+
+    const [responseVideo, responseSource] = await Promise.all([
+      fetchWithBrightCoveToken(brightcoveVideoUrl, context),
+      fetchWithBrightCoveToken(brightcoveSourceUrl, context),
+    ]);
+    const brightcoveVideo: BrightcoveApiType = await resolveJson(responseVideo);
+    const brightcoveSources: BrightcoveVideoSource[] = await resolveJson(
+      responseSource,
+    );
+
+    const licenseInfo = Object.keys(brightcoveVideo.custom_fields)
+      .filter(key => key.startsWith('licenseinfo'))
+      .map(key => brightcoveVideo.custom_fields[key]);
+
+    const source = sortBy(
+      brightcoveSources.filter(source => source.width && source.height),
+      source => source.height,
+    )[0];
+    const download = sortBy(
+      brightcoveSources.filter(
+        source => source.container === 'MP4' && source.src,
+      ),
+      source => source.size,
+    );
+    return {
+      videoid: id,
+      iframe: {
+        height: source?.height ?? 480,
+        width: source?.width ?? 640,
+        src: source.src,
+      },
+      download: download[0]?.src,
+      customFields: {
+        licenseInfo: licenseInfo,
+        license: brightcoveVideo.custom_fields.license,
+        accountId: accountId,
+      },
+    };
+  } catch (e) {
+    return null;
+  }
+}
+
+export const fetchWithBrightCoveToken = async (
+  url: string,
+  context: Context,
+) => {
+  const response = await fetchBrightcoveAccessToken(context);
+  return await fetch(url, { ...context, token: response });
+};
+
+const fetchBrightcoveAccessToken = async (context: Context) =>
+  await fetch(brightcoveTokenUrl, context, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+      Authorization: `Basic ${b64EncodeUnicode(clientIdSecret)}`,
+    },
+    method: 'POST',
+    body: 'grant_type=client_credentials',
+  }).then(token => token.json());
+
+export interface BrightcoveVideoSource {
+  container?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+  src: string;
+}
+
+export interface BrightcoveApiType {
+  account_id?: string | null;
+  custom_fields: Record<string, string>;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,21 @@ const ndlaFrontendUrl = () => {
   }
 };
 
+export const h5pHostUrl = () => {
+  const h5pHost = process.env.H5P_HOST;
+  if (!h5pHost) {
+    switch (process.env.NDLA_ENVIRONMENT) {
+      case 'prod':
+        return 'https://h5p.ndla.no';
+      default:
+        return `https://h5p-${ndlaEnvironment.toString().replace('_', '-') ||
+          'test'}.ndla.no`;
+    }
+  } else {
+    return h5pHost;
+  }
+};
+
 export const port = getEnvironmentVariabel('PORT', '4000');
 export const apiUrl = getEnvironmentVariabel('API_URL', ndlaApiUrl());
 export const localConverter = getEnvironmentVariabel('LOCAL_CONVERTER', false);

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -55,6 +55,7 @@ import {
   Query as FolderResolvers,
   Mutations as FolderMutations,
 } from './folderResolvers';
+import { Query as VideoQuery } from './videoResolvers';
 
 export const resolvers = {
   Query: {
@@ -70,6 +71,7 @@ export const resolvers = {
     ...ConceptQuery,
     ...UptimeQuery,
     ...FolderResolvers,
+    ...VideoQuery,
   },
   Mutation: {
     ...FolderMutations,

--- a/src/resolvers/videoResolvers.ts
+++ b/src/resolvers/videoResolvers.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { GQLBrightcoveElement, GQLQueryBrightcoveVideoArgs } from 'schema';
+import { fetchBrightcoveVideo } from '../api/videoApi';
+
+export const Query = {
+  async brightcoveVideo(
+    _: any,
+    { id }: GQLQueryBrightcoveVideoArgs,
+    context: Context,
+  ): Promise<GQLBrightcoveElement | null> {
+    return fetchBrightcoveVideo(id, context);
+  },
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -783,6 +783,7 @@ export const typeDefs = gql`
     iframe: BrightcoveIframe
     uploadDate: String
     customFields: BrightcoveCustomFields
+    name: String
   }
 
   type BrightcoveCustomFields {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -742,6 +742,13 @@ export const typeDefs = gql`
     download: String
     iframe: BrightcoveIframe
     uploadDate: String
+    customFields: BrightcoveCustomFields
+  }
+
+  type BrightcoveCustomFields {
+    license: String!
+    licenseInfo: [String!]!
+    accountId: String
   }
 
   type H5pElement {
@@ -1065,6 +1072,7 @@ export const typeDefs = gql`
     ): Folder!
     allFolderResources(size: Int): [FolderResource!]!
     personalData: MyNdlaPersonalData!
+    brightcoveVideo(id: String!): BrightcoveElement
   }
 
   type Mutation {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -193,11 +193,19 @@ export type GQLBreadcrumb = {
   name: Scalars['String'];
 };
 
+export type GQLBrightcoveCustomFields = {
+  __typename?: 'BrightcoveCustomFields';
+  accountId?: Maybe<Scalars['String']>;
+  license: Scalars['String'];
+  licenseInfo: Array<Scalars['String']>;
+};
+
 export type GQLBrightcoveElement = {
   __typename?: 'BrightcoveElement';
   account?: Maybe<Scalars['String']>;
   caption?: Maybe<Scalars['String']>;
   cover?: Maybe<Scalars['String']>;
+  customFields?: Maybe<GQLBrightcoveCustomFields>;
   description?: Maybe<Scalars['String']>;
   download?: Maybe<Scalars['String']>;
   iframe?: Maybe<GQLBrightcoveIframe>;
@@ -859,6 +867,7 @@ export type GQLQuery = {
   alerts?: Maybe<Array<Maybe<GQLUptimeAlert>>>;
   allFolderResources: Array<GQLFolderResource>;
   article?: Maybe<GQLArticle>;
+  brightcoveVideo?: Maybe<GQLBrightcoveElement>;
   competenceGoal?: Maybe<GQLCompetenceGoal>;
   competenceGoals?: Maybe<Array<GQLCompetenceGoal>>;
   concept?: Maybe<GQLConcept>;
@@ -903,6 +912,11 @@ export type GQLQueryArticleArgs = {
   path?: InputMaybe<Scalars['String']>;
   showVisualElement?: InputMaybe<Scalars['String']>;
   subjectId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type GQLQueryBrightcoveVideoArgs = {
+  id: Scalars['String'];
 };
 
 
@@ -1518,6 +1532,7 @@ export type GQLResolversTypes = {
   AudioWithSeries: ResolverTypeWrapper<GQLAudioWithSeries>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   Breadcrumb: ResolverTypeWrapper<GQLBreadcrumb>;
+  BrightcoveCustomFields: ResolverTypeWrapper<GQLBrightcoveCustomFields>;
   BrightcoveElement: ResolverTypeWrapper<GQLBrightcoveElement>;
   BrightcoveIframe: ResolverTypeWrapper<GQLBrightcoveIframe>;
   BrightcoveLicense: ResolverTypeWrapper<GQLBrightcoveLicense>;
@@ -1640,6 +1655,7 @@ export type GQLResolversParentTypes = {
   AudioWithSeries: GQLAudioWithSeries;
   Boolean: Scalars['Boolean'];
   Breadcrumb: GQLBreadcrumb;
+  BrightcoveCustomFields: GQLBrightcoveCustomFields;
   BrightcoveElement: GQLBrightcoveElement;
   BrightcoveIframe: GQLBrightcoveIframe;
   BrightcoveLicense: GQLBrightcoveLicense;
@@ -1919,10 +1935,18 @@ export type GQLBreadcrumbResolvers<ContextType = any, ParentType extends GQLReso
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLBrightcoveCustomFieldsResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['BrightcoveCustomFields'] = GQLResolversParentTypes['BrightcoveCustomFields']> = {
+  accountId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  license?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  licenseInfo?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLBrightcoveElementResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['BrightcoveElement'] = GQLResolversParentTypes['BrightcoveElement']> = {
   account?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   caption?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   cover?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  customFields?: Resolver<Maybe<GQLResolversTypes['BrightcoveCustomFields']>, ParentType, ContextType>;
   description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   download?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   iframe?: Resolver<Maybe<GQLResolversTypes['BrightcoveIframe']>, ParentType, ContextType>;
@@ -2522,6 +2546,7 @@ export type GQLQueryResolvers<ContextType = any, ParentType extends GQLResolvers
   alerts?: Resolver<Maybe<Array<Maybe<GQLResolversTypes['UptimeAlert']>>>, ParentType, ContextType>;
   allFolderResources?: Resolver<Array<GQLResolversTypes['FolderResource']>, ParentType, ContextType, Partial<GQLQueryAllFolderResourcesArgs>>;
   article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType, RequireFields<GQLQueryArticleArgs, 'id'>>;
+  brightcoveVideo?: Resolver<Maybe<GQLResolversTypes['BrightcoveElement']>, ParentType, ContextType, RequireFields<GQLQueryBrightcoveVideoArgs, 'id'>>;
   competenceGoal?: Resolver<Maybe<GQLResolversTypes['CompetenceGoal']>, ParentType, ContextType, RequireFields<GQLQueryCompetenceGoalArgs, 'code'>>;
   competenceGoals?: Resolver<Maybe<Array<GQLResolversTypes['CompetenceGoal']>>, ParentType, ContextType, Partial<GQLQueryCompetenceGoalsArgs>>;
   concept?: Resolver<Maybe<GQLResolversTypes['Concept']>, ParentType, ContextType, RequireFields<GQLQueryConceptArgs, 'id'>>;
@@ -2862,6 +2887,7 @@ export type GQLResolvers<ContextType = any> = {
   AudioSummary?: GQLAudioSummaryResolvers<ContextType>;
   AudioWithSeries?: GQLAudioWithSeriesResolvers<ContextType>;
   Breadcrumb?: GQLBreadcrumbResolvers<ContextType>;
+  BrightcoveCustomFields?: GQLBrightcoveCustomFieldsResolvers<ContextType>;
   BrightcoveElement?: GQLBrightcoveElementResolvers<ContextType>;
   BrightcoveIframe?: GQLBrightcoveIframeResolvers<ContextType>;
   BrightcoveLicense?: GQLBrightcoveLicenseResolvers<ContextType>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -209,6 +209,7 @@ export type GQLBrightcoveElement = {
   description?: Maybe<Scalars['String']>;
   download?: Maybe<Scalars['String']>;
   iframe?: Maybe<GQLBrightcoveIframe>;
+  name?: Maybe<Scalars['String']>;
   player?: Maybe<Scalars['String']>;
   src?: Maybe<Scalars['String']>;
   uploadDate?: Maybe<Scalars['String']>;
@@ -2011,6 +2012,7 @@ export type GQLBrightcoveElementResolvers<ContextType = any, ParentType extends 
   description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   download?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   iframe?: Resolver<Maybe<GQLResolversTypes['BrightcoveIframe']>, ParentType, ContextType>;
+  name?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   player?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   src?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   uploadDate?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;

--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -43,7 +43,7 @@ export async function parseVisualElement(
 
   switch (data?.resource) {
     case 'brightcove':
-      return await parseBrightcoveFromEmbed(data, context);
+      return await parseBrightcoveFromEmbed(data, context, visualElementEmbed);
     case 'h5p':
       return await parseH5PFromEmbed(data, context, visualElementEmbed);
     case 'image':
@@ -58,9 +58,10 @@ export async function parseVisualElement(
 const parseBrightcoveFromEmbed = async (
   embedData: any,
   context: Context,
+  visualElementEmbed: string,
 ): Promise<GQLVisualElement> => {
   const license = await fetchVisualElementLicense<GQLBrightcoveLicense>(
-    embedData,
+    visualElementEmbed,
     'brightcoves',
     context,
   );
@@ -70,6 +71,7 @@ const parseBrightcoveFromEmbed = async (
       ...license,
       ...embedData,
     },
+    copyright: license.copyright,
     resource: 'brightcove',
   };
 };


### PR DESCRIPTION
La til funksjonalitet til å kunne `querye` spesifikke brightcove videoer med bruke av deres videoId. Til nytte for https://github.com/NDLANO/ndla-frontend/pull/1256. 

Hva er gjort: 
- Eget videoapi modul som tar seg av fetchingen til brightcove. **NOTE** Siden det kjøres på `node` så har vi ikke tilgang til å lagre accesstoken så  for å gjøre det enkelt  fetches det ved hver query. 
- Refaktorerte visualelement parseren for mer readability

Mangler: 
- Legge til environment variabler