### PR TITLE
Fetch only topics.

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -181,6 +181,7 @@ export async function fetchSubjectTopics(
 ): Promise<GQLTopic[]> {
   const query = qs.stringify({
     recursive: true,
+    nodeType: 'TOPIC',
     language: context.language,
   });
   const response = await taxonomyFetch(
@@ -196,6 +197,7 @@ export async function fetchTopics(
 ): Promise<GQLTopic[]> {
   const query = qs.stringify({
     contentURI: args.contentUri ?? '',
+    nodeType: 'TOPIC',
     language: context.language,
   });
   const response = await taxonomyFetch(
@@ -224,6 +226,7 @@ export async function fetchSubtopics(
 ): Promise<GQLTopic[]> {
   const { id } = params;
   const query = qs.stringify({
+    nodeType: 'TOPIC',
     language: context.language,
   });
   const response = await taxonomyFetch(


### PR DESCRIPTION
Legger på filter på topics ved henting fra taksonomi.
Avhenger av https://github.com/NDLANO/taxonomy-api/pull/176

Taksonomi er deploya til test, så denne lokalt sammen med ndla-frontend vil fungere slik at ressurser ikkje lenger vises som emner på emneside.