### PR TITLE
Convert Mathml children to stringified html

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -74,7 +74,7 @@ const _fetchTransformedArticle = async (
     });
     html('math').each((_, el) => {
       html(el)
-        .attr('data-math', html(el).html())
+        .attr('data-math', html(el).html() ?? '')
         .children()
         .replaceWith('');
     });

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -72,6 +72,12 @@ const _fetchTransformedArticle = async (
       xmlMode: false,
       decodeEntities: false,
     });
+    html('math').each((_, el) => {
+      html(el)
+        .attr('data-math', html(el).html())
+        .children()
+        .replaceWith('');
+    });
     if (params.showVisualElement && article.visualElement?.visualElement) {
       html('body').prepend(
         `<section>${article.visualElement.visualElement}</section>`,


### PR DESCRIPTION
Det ser ut til at react fjerner visse attributter fra mathml når man bruker `createElement`. Dette fører blant annet til at opening-brackets på mathml går fra å være f.eks "{" til "". Måten man kommer seg rundt dette på er å holde Mathml-kode helt utenfor React. Dette er en del av løsningen for dette. Ved å fjerne barna til `math`-elementer, og heller legge det ved som stringified html har vi muligheten til å kjøre `dangerouslySetInnerHTML` på de i article-converter.