### PR TITLE
Throw 410 error when encountering a 410

### DIFF
--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -95,6 +95,16 @@ export async function resolveJson(
     return;
   }
 
+  if (status === 410) {
+    throw new GraphQLError(statusText, {
+      extensions: {
+        http: {
+          status: 410,
+        },
+      },
+    });
+  }
+
   const json = await response.json();
   if (ok) {
     return externalsToH5pMetaData(json);


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3386
GQL behandler alle feil som 200 som en konvensjon. Dette sørger for at GQL faktisk kaster en 410 når den mottar en 410. Usikker på om det kommer til å påvirke oss andre steder. Dersom det er greit at vi får en 410 i en annen spørring kan dette kanskje by på trøbbel?