### PR TITLE
Add possibility to add videos, concepts, images and audio to my ndla

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@ndla/types-embed": "^0.1.4",
     "@ndla/types-frontpage-api": "^0.0.4",
     "@ndla/types-image-api": "^0.0.10",
-    "@ndla/types-learningpath-api": "^0.0.19",
+    "@ndla/types-learningpath-api": "^0.0.20",
     "@ndla/types-search-api": "^0.0.6",
     "@types/bunyan": "^1.8.5",
     "@types/compression": "^1.7.2",

--- a/src/resolvers/folderResolvers.ts
+++ b/src/resolvers/folderResolvers.ts
@@ -112,6 +112,25 @@ export const Query: Pick<
     return getPersonalData(context);
   },
 };
+
+export const resolvers = {
+  Folder: {
+    async id(folder: IFolderData, _: any, context: ContextWithLoaders) {
+      return folder.id.toString();
+    },
+  },
+  FolderResource: {
+    async id(resource: IResource, _: any, context: ContextWithLoaders) {
+      return resource.id.toString();
+    },
+  },
+  FolderResourceMeta: {
+    async id(meta: GQLFolderResourceMeta, _: any, context: ContextWithLoaders) {
+      return meta.id.toString();
+    },
+  },
+};
+
 export const Mutations: Pick<
   GQLMutationResolvers,
   | 'addFolder'

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -54,6 +54,7 @@ import {
 import {
   Query as FolderResolvers,
   Mutations as FolderMutations,
+  resolvers as folderResolvers,
 } from './folderResolvers';
 import { Query as VideoQuery } from './videoResolvers';
 import {
@@ -83,6 +84,7 @@ export const resolvers = {
     ...FolderMutations,
     ...TransformArticleMutations,
   },
+  ...folderResolvers,
   ...articleResolvers,
   ...subjectResolvers,
   ...topicResolvers,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -902,11 +902,13 @@ export const typeDefs = gql`
     parentId: String
     subfolders: [Folder!]!
     resources: [FolderResource!]!
+    created: String!
+    updated: String!
   }
 
   type FolderResource {
     id: String!
-    resourceId: Int!
+    resourceId: String!
     resourceType: String!
     path: String!
     created: String!
@@ -914,7 +916,7 @@ export const typeDefs = gql`
   }
 
   input FolderResourceMetaSearchInput {
-    id: Int!
+    id: String!
     resourceType: String!
     path: String!
   }
@@ -925,7 +927,7 @@ export const typeDefs = gql`
   }
 
   interface FolderResourceMeta {
-    id: Int!
+    id: String!
     type: String!
     resourceTypes: [FolderResourceResourceType!]!
     metaImage: MetaImage
@@ -934,7 +936,7 @@ export const typeDefs = gql`
   }
 
   type ArticleFolderResourceMeta implements FolderResourceMeta {
-    id: Int!
+    id: String!
     type: String!
     resourceTypes: [FolderResourceResourceType!]!
     metaImage: MetaImage
@@ -943,7 +945,43 @@ export const typeDefs = gql`
   }
 
   type LearningpathFolderResourceMeta implements FolderResourceMeta {
-    id: Int!
+    id: String!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type ConceptFolderResourceMeta implements FolderResourceMeta {
+    id: String!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type ImageFolderResourceMeta implements FolderResourceMeta {
+    id: String!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type AudioFolderResourceMeta implements FolderResourceMeta {
+    id: String!
+    type: String!
+    resourceTypes: [FolderResourceResourceType!]!
+    metaImage: MetaImage
+    title: String!
+    description: String!
+  }
+
+  type VideoFolderResourceMeta implements FolderResourceMeta {
+    id: String!
     type: String!
     resourceTypes: [FolderResourceResourceType!]!
     metaImage: MetaImage
@@ -1108,7 +1146,7 @@ export const typeDefs = gql`
     updateFolder(id: String!, name: String, status: String): Folder!
     deleteFolder(id: String!): String!
     addFolderResource(
-      resourceId: Int!
+      resourceId: String!
       folderId: String!
       resourceType: String!
       path: String!

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -63,7 +63,7 @@ export type GQLArticleCrossSubjectTopicsArgs = {
 export type GQLArticleFolderResourceMeta = GQLFolderResourceMeta & {
   __typename?: 'ArticleFolderResourceMeta';
   description: Scalars['String'];
-  id: Scalars['Int'];
+  id: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
   resourceTypes: Array<GQLFolderResourceResourceType>;
   title: Scalars['String'];
@@ -124,6 +124,16 @@ export type GQLAudioFile = {
   language: Scalars['String'];
   mimeType: Scalars['String'];
   url: Scalars['String'];
+};
+
+export type GQLAudioFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'AudioFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['String'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
 };
 
 export type GQLAudioLicense = {
@@ -267,6 +277,16 @@ export type GQLConceptCopyright = {
   rightsholders: Array<GQLContributor>;
 };
 
+export type GQLConceptFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'ConceptFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['String'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export type GQLConceptLicense = {
   __typename?: 'ConceptLicense';
   copyright?: Maybe<GQLConceptCopyright>;
@@ -365,12 +385,14 @@ export type GQLFilmPageAbout = {
 export type GQLFolder = {
   __typename?: 'Folder';
   breadcrumbs: Array<GQLBreadcrumb>;
+  created: Scalars['String'];
   id: Scalars['String'];
   name: Scalars['String'];
   parentId?: Maybe<Scalars['String']>;
   resources: Array<GQLFolderResource>;
   status: Scalars['String'];
   subfolders: Array<GQLFolder>;
+  updated: Scalars['String'];
 };
 
 export type GQLFolderResource = {
@@ -378,14 +400,14 @@ export type GQLFolderResource = {
   created: Scalars['String'];
   id: Scalars['String'];
   path: Scalars['String'];
-  resourceId: Scalars['Int'];
+  resourceId: Scalars['String'];
   resourceType: Scalars['String'];
   tags: Array<Scalars['String']>;
 };
 
 export type GQLFolderResourceMeta = {
   description: Scalars['String'];
-  id: Scalars['Int'];
+  id: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
   resourceTypes: Array<GQLFolderResourceResourceType>;
   title: Scalars['String'];
@@ -393,7 +415,7 @@ export type GQLFolderResourceMeta = {
 };
 
 export type GQLFolderResourceMetaSearchInput = {
-  id: Scalars['Int'];
+  id: Scalars['String'];
   path: Scalars['String'];
   resourceType: Scalars['String'];
 };
@@ -511,6 +533,16 @@ export type GQLImageElement = {
   upperLeftY?: Maybe<Scalars['Float']>;
 };
 
+export type GQLImageFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'ImageFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['String'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export type GQLImageLicense = {
   __typename?: 'ImageLicense';
   altText: Scalars['String'];
@@ -594,7 +626,7 @@ export type GQLLearningpathCoverphoto = {
 export type GQLLearningpathFolderResourceMeta = GQLFolderResourceMeta & {
   __typename?: 'LearningpathFolderResourceMeta';
   description: Scalars['String'];
-  id: Scalars['Int'];
+  id: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
   resourceTypes: Array<GQLFolderResourceResourceType>;
   title: Scalars['String'];
@@ -744,7 +776,7 @@ export type GQLMutationAddFolderArgs = {
 export type GQLMutationAddFolderResourceArgs = {
   folderId: Scalars['String'];
   path: Scalars['String'];
-  resourceId: Scalars['Int'];
+  resourceId: Scalars['String'];
   resourceType: Scalars['String'];
   tags?: InputMaybe<Array<Scalars['String']>>;
 };
@@ -1474,6 +1506,16 @@ export type GQLUptimeAlert = {
   title: Scalars['String'];
 };
 
+export type GQLVideoFolderResourceMeta = GQLFolderResourceMeta & {
+  __typename?: 'VideoFolderResourceMeta';
+  description: Scalars['String'];
+  id: Scalars['String'];
+  metaImage?: Maybe<GQLMetaImage>;
+  resourceTypes: Array<GQLFolderResourceResourceType>;
+  title: Scalars['String'];
+  type: Scalars['String'];
+};
+
 export type GQLVisualElement = {
   __typename?: 'VisualElement';
   brightcove?: Maybe<GQLBrightcoveElement>;
@@ -1577,6 +1619,7 @@ export type GQLResolversTypes = {
   ArticleSearchResult: ResolverTypeWrapper<GQLArticleSearchResult>;
   Audio: ResolverTypeWrapper<GQLAudio>;
   AudioFile: ResolverTypeWrapper<GQLAudioFile>;
+  AudioFolderResourceMeta: ResolverTypeWrapper<GQLAudioFolderResourceMeta>;
   AudioLicense: ResolverTypeWrapper<GQLAudioLicense>;
   AudioSearch: ResolverTypeWrapper<GQLAudioSearch>;
   AudioSummary: ResolverTypeWrapper<GQLAudioSummary>;
@@ -1592,6 +1635,7 @@ export type GQLResolversTypes = {
   CompetenceGoal: ResolverTypeWrapper<GQLCompetenceGoal>;
   Concept: ResolverTypeWrapper<GQLConcept>;
   ConceptCopyright: ResolverTypeWrapper<GQLConceptCopyright>;
+  ConceptFolderResourceMeta: ResolverTypeWrapper<GQLConceptFolderResourceMeta>;
   ConceptLicense: ResolverTypeWrapper<GQLConceptLicense>;
   ConceptResult: ResolverTypeWrapper<GQLConceptResult>;
   Contributor: ResolverTypeWrapper<GQLContributor>;
@@ -1608,7 +1652,7 @@ export type GQLResolversTypes = {
   Float: ResolverTypeWrapper<Scalars['Float']>;
   Folder: ResolverTypeWrapper<GQLFolder>;
   FolderResource: ResolverTypeWrapper<GQLFolderResource>;
-  FolderResourceMeta: GQLResolversTypes['ArticleFolderResourceMeta'] | GQLResolversTypes['LearningpathFolderResourceMeta'];
+  FolderResourceMeta: GQLResolversTypes['ArticleFolderResourceMeta'] | GQLResolversTypes['AudioFolderResourceMeta'] | GQLResolversTypes['ConceptFolderResourceMeta'] | GQLResolversTypes['ImageFolderResourceMeta'] | GQLResolversTypes['LearningpathFolderResourceMeta'] | GQLResolversTypes['VideoFolderResourceMeta'];
   FolderResourceMetaSearchInput: GQLFolderResourceMetaSearchInput;
   FolderResourceResourceType: ResolverTypeWrapper<GQLFolderResourceResourceType>;
   FootNote: ResolverTypeWrapper<GQLFootNote>;
@@ -1623,6 +1667,7 @@ export type GQLResolversTypes = {
   ImageAltText: ResolverTypeWrapper<GQLImageAltText>;
   ImageDimensions: ResolverTypeWrapper<GQLImageDimensions>;
   ImageElement: ResolverTypeWrapper<GQLImageElement>;
+  ImageFolderResourceMeta: ResolverTypeWrapper<GQLImageFolderResourceMeta>;
   ImageLicense: ResolverTypeWrapper<GQLImageLicense>;
   ImageMetaInformation: ResolverTypeWrapper<GQLImageMetaInformation>;
   ImageMetaInformationV2: ResolverTypeWrapper<GQLImageMetaInformationV2>;
@@ -1688,6 +1733,7 @@ export type GQLResolversTypes = {
   UpdatedFolder: ResolverTypeWrapper<GQLUpdatedFolder>;
   UpdatedFolderResource: ResolverTypeWrapper<GQLUpdatedFolderResource>;
   UptimeAlert: ResolverTypeWrapper<GQLUptimeAlert>;
+  VideoFolderResourceMeta: ResolverTypeWrapper<GQLVideoFolderResourceMeta>;
   VisualElement: ResolverTypeWrapper<GQLVisualElement>;
   VisualElementOembed: ResolverTypeWrapper<GQLVisualElementOembed>;
   WithArticle: GQLResolversTypes['Resource'] | GQLResolversTypes['Topic'];
@@ -1703,6 +1749,7 @@ export type GQLResolversParentTypes = {
   ArticleSearchResult: GQLArticleSearchResult;
   Audio: GQLAudio;
   AudioFile: GQLAudioFile;
+  AudioFolderResourceMeta: GQLAudioFolderResourceMeta;
   AudioLicense: GQLAudioLicense;
   AudioSearch: GQLAudioSearch;
   AudioSummary: GQLAudioSummary;
@@ -1718,6 +1765,7 @@ export type GQLResolversParentTypes = {
   CompetenceGoal: GQLCompetenceGoal;
   Concept: GQLConcept;
   ConceptCopyright: GQLConceptCopyright;
+  ConceptFolderResourceMeta: GQLConceptFolderResourceMeta;
   ConceptLicense: GQLConceptLicense;
   ConceptResult: GQLConceptResult;
   Contributor: GQLContributor;
@@ -1734,7 +1782,7 @@ export type GQLResolversParentTypes = {
   Float: Scalars['Float'];
   Folder: GQLFolder;
   FolderResource: GQLFolderResource;
-  FolderResourceMeta: GQLResolversParentTypes['ArticleFolderResourceMeta'] | GQLResolversParentTypes['LearningpathFolderResourceMeta'];
+  FolderResourceMeta: GQLResolversParentTypes['ArticleFolderResourceMeta'] | GQLResolversParentTypes['AudioFolderResourceMeta'] | GQLResolversParentTypes['ConceptFolderResourceMeta'] | GQLResolversParentTypes['ImageFolderResourceMeta'] | GQLResolversParentTypes['LearningpathFolderResourceMeta'] | GQLResolversParentTypes['VideoFolderResourceMeta'];
   FolderResourceMetaSearchInput: GQLFolderResourceMetaSearchInput;
   FolderResourceResourceType: GQLFolderResourceResourceType;
   FootNote: GQLFootNote;
@@ -1749,6 +1797,7 @@ export type GQLResolversParentTypes = {
   ImageAltText: GQLImageAltText;
   ImageDimensions: GQLImageDimensions;
   ImageElement: GQLImageElement;
+  ImageFolderResourceMeta: GQLImageFolderResourceMeta;
   ImageLicense: GQLImageLicense;
   ImageMetaInformation: GQLImageMetaInformation;
   ImageMetaInformationV2: GQLImageMetaInformationV2;
@@ -1814,6 +1863,7 @@ export type GQLResolversParentTypes = {
   UpdatedFolder: GQLUpdatedFolder;
   UpdatedFolderResource: GQLUpdatedFolderResource;
   UptimeAlert: GQLUptimeAlert;
+  VideoFolderResourceMeta: GQLVideoFolderResourceMeta;
   VisualElement: GQLVisualElement;
   VisualElementOembed: GQLVisualElementOembed;
   WithArticle: GQLResolversParentTypes['Resource'] | GQLResolversParentTypes['Topic'];
@@ -1861,7 +1911,7 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
 
 export type GQLArticleFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ArticleFolderResourceMeta'] = GQLResolversParentTypes['ArticleFolderResourceMeta']> = {
   description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -1922,6 +1972,16 @@ export type GQLAudioFileResolvers<ContextType = any, ParentType extends GQLResol
   language?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   mimeType?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   url?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLAudioFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['AudioFolderResourceMeta'] = GQLResolversParentTypes['AudioFolderResourceMeta']> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2066,6 +2126,16 @@ export type GQLConceptCopyrightResolvers<ContextType = any, ParentType extends G
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLConceptFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ConceptFolderResourceMeta'] = GQLResolversParentTypes['ConceptFolderResourceMeta']> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLConceptLicenseResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ConceptLicense'] = GQLResolversParentTypes['ConceptLicense']> = {
   copyright?: Resolver<Maybe<GQLResolversTypes['ConceptCopyright']>, ParentType, ContextType>;
   src?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -2163,12 +2233,14 @@ export type GQLFilmPageAboutResolvers<ContextType = any, ParentType extends GQLR
 
 export type GQLFolderResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Folder'] = GQLResolversParentTypes['Folder']> = {
   breadcrumbs?: Resolver<Array<GQLResolversTypes['Breadcrumb']>, ParentType, ContextType>;
+  created?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   parentId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   resources?: Resolver<Array<GQLResolversTypes['FolderResource']>, ParentType, ContextType>;
   status?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   subfolders?: Resolver<Array<GQLResolversTypes['Folder']>, ParentType, ContextType>;
+  updated?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2176,16 +2248,16 @@ export type GQLFolderResourceResolvers<ContextType = any, ParentType extends GQL
   created?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  resourceId?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  resourceId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   resourceType?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   tags?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
 export type GQLFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['FolderResourceMeta'] = GQLResolversParentTypes['FolderResourceMeta']> = {
-  __resolveType: TypeResolveFn<'ArticleFolderResourceMeta' | 'LearningpathFolderResourceMeta', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleFolderResourceMeta' | 'AudioFolderResourceMeta' | 'ConceptFolderResourceMeta' | 'ImageFolderResourceMeta' | 'LearningpathFolderResourceMeta' | 'VideoFolderResourceMeta', ParentType, ContextType>;
   description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -2305,6 +2377,16 @@ export type GQLImageElementResolvers<ContextType = any, ParentType extends GQLRe
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLImageFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ImageFolderResourceMeta'] = GQLResolversParentTypes['ImageFolderResourceMeta']> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLImageLicenseResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ImageLicense'] = GQLResolversParentTypes['ImageLicense']> = {
   altText?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   contentType?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -2387,7 +2469,7 @@ export type GQLLearningpathCoverphotoResolvers<ContextType = any, ParentType ext
 
 export type GQLLearningpathFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['LearningpathFolderResourceMeta'] = GQLResolversParentTypes['LearningpathFolderResourceMeta']> = {
   description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -2921,6 +3003,16 @@ export type GQLUptimeAlertResolvers<ContextType = any, ParentType extends GQLRes
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLVideoFolderResourceMetaResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['VideoFolderResourceMeta'] = GQLResolversParentTypes['VideoFolderResourceMeta']> = {
+  description?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  resourceTypes?: Resolver<Array<GQLResolversTypes['FolderResourceResourceType']>, ParentType, ContextType>;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLVisualElementResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['VisualElement'] = GQLResolversParentTypes['VisualElement']> = {
   brightcove?: Resolver<Maybe<GQLResolversTypes['BrightcoveElement']>, ParentType, ContextType>;
   copyright?: Resolver<Maybe<GQLResolversTypes['Copyright']>, ParentType, ContextType>;
@@ -2957,6 +3049,7 @@ export type GQLResolvers<ContextType = any> = {
   ArticleSearchResult?: GQLArticleSearchResultResolvers<ContextType>;
   Audio?: GQLAudioResolvers<ContextType>;
   AudioFile?: GQLAudioFileResolvers<ContextType>;
+  AudioFolderResourceMeta?: GQLAudioFolderResourceMetaResolvers<ContextType>;
   AudioLicense?: GQLAudioLicenseResolvers<ContextType>;
   AudioSearch?: GQLAudioSearchResolvers<ContextType>;
   AudioSummary?: GQLAudioSummaryResolvers<ContextType>;
@@ -2971,6 +3064,7 @@ export type GQLResolvers<ContextType = any> = {
   CompetenceGoal?: GQLCompetenceGoalResolvers<ContextType>;
   Concept?: GQLConceptResolvers<ContextType>;
   ConceptCopyright?: GQLConceptCopyrightResolvers<ContextType>;
+  ConceptFolderResourceMeta?: GQLConceptFolderResourceMetaResolvers<ContextType>;
   ConceptLicense?: GQLConceptLicenseResolvers<ContextType>;
   ConceptResult?: GQLConceptResultResolvers<ContextType>;
   Contributor?: GQLContributorResolvers<ContextType>;
@@ -3000,6 +3094,7 @@ export type GQLResolvers<ContextType = any> = {
   ImageAltText?: GQLImageAltTextResolvers<ContextType>;
   ImageDimensions?: GQLImageDimensionsResolvers<ContextType>;
   ImageElement?: GQLImageElementResolvers<ContextType>;
+  ImageFolderResourceMeta?: GQLImageFolderResourceMetaResolvers<ContextType>;
   ImageLicense?: GQLImageLicenseResolvers<ContextType>;
   ImageMetaInformation?: GQLImageMetaInformationResolvers<ContextType>;
   ImageMetaInformationV2?: GQLImageMetaInformationV2Resolvers<ContextType>;
@@ -3063,6 +3158,7 @@ export type GQLResolvers<ContextType = any> = {
   UpdatedFolder?: GQLUpdatedFolderResolvers<ContextType>;
   UpdatedFolderResource?: GQLUpdatedFolderResourceResolvers<ContextType>;
   UptimeAlert?: GQLUptimeAlertResolvers<ContextType>;
+  VideoFolderResourceMeta?: GQLVideoFolderResourceMetaResolvers<ContextType>;
   VisualElement?: GQLVisualElementResolvers<ContextType>;
   VisualElementOembed?: GQLVisualElementOembedResolvers<ContextType>;
   WithArticle?: GQLWithArticleResolvers<ContextType>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,10 +1516,10 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-image-api/-/types-image-api-0.0.10.tgz#0b358825e5ded24d602576997019492ffdd77160"
   integrity sha512-/wlnvskF8xHzNx4ZPsxgaJDqs3jGURgC28mMljlPtgOgK07/1QemKaJIPAmSGNcxBIzMhNiBkkFDYbHw8pxOGw==
 
-"@ndla/types-learningpath-api@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@ndla/types-learningpath-api/-/types-learningpath-api-0.0.19.tgz#e8631e0dd42fb05f15a6f9fc3e2e60dbfbe7d032"
-  integrity sha512-vpRkP/G1SzkJ3ENDq5W27XPtsnOD/mc5EmnZwXWc0eEgnCfhHqchXKMT+TzlnkNP9AtFjs5pIP7RKd+796IXbQ==
+"@ndla/types-learningpath-api@^0.0.20":
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/@ndla/types-learningpath-api/-/types-learningpath-api-0.0.20.tgz#5794c7300834fb857199f26fa934823102003b2e"
+  integrity sha512-uiM43AhkqSYFGVpwitixQM1ksmn4QqMqNN0O3S2wssAWT9koWxa4o1GjysUm8WwlCz774qOVWqnZJ0dEXjHTeQ==
 
 "@ndla/types-search-api@^0.0.6":
   version "0.0.6"


### PR DESCRIPTION
Legger til mulighet for å hjertemerke bilder, lyder, forklaringer, og videoer. Skriver om mapperessurs-ID'er til å være strings. Merk: Dette kommer ikke til å funke med PUT, DELETE og POST uten ny backend. Har dog lagt inn resolvers så fetching skal fungere fint.