### PR TITLE
Rewrite embedsApi so that one can choose whether to suppress errors or not

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@graphql-codegen/typescript-resolvers": "^2.7.6",
     "@graphql-eslint/eslint-plugin": "^3.12.0",
     "@ndla/types-backend": "^0.2.2",
-    "@ndla/types-embed": "^1.1.0",
+    "@ndla/types-embed": "^2.0.0",
     "@types/bunyan": "^1.8.5",
     "@types/compression": "^1.7.2",
     "@types/cors": "^2.8.4",

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -27,6 +27,17 @@ export async function fetchAudio(
   }
 }
 
+export async function fetchAudioV2(
+  context: Context,
+  audioId: number | string,
+): Promise<IAudioMetaInformation> {
+  const response = await fetch(
+    `/audio-api/v1/audio/${audioId}?language=${context.language}`,
+    context,
+  );
+  return await resolveJson(response);
+}
+
 export async function fetchPodcastsPage(
   context: Context,
   pageSize: number,

--- a/src/api/transformArticleApi.ts
+++ b/src/api/transformArticleApi.ts
@@ -77,14 +77,14 @@ export const toVisualElement = (
     case 'image':
       return {
         resource: 'image',
-        url: meta.data.imageUrl,
+        url: meta.data.image.imageUrl,
         title: meta.data.title.title,
         copyright: meta.data.copyright,
         image: {
           caption: meta.embedData.caption ?? meta.data.caption.caption,
           alt: meta.embedData.alt,
           altText: meta.data.alttext.alttext,
-          src: meta.data.imageUrl,
+          src: meta.data.image.imageUrl,
           focalX: Number(meta.embedData.focalX) || undefined,
           focalY: Number(meta.embedData.focalY) || undefined,
           lowerRightX: Number(meta.embedData.lowerRightX) || undefined,

--- a/src/utils/toArticleMetaData.ts
+++ b/src/utils/toArticleMetaData.ts
@@ -8,7 +8,7 @@
 
 import { IConcept, IConceptSummary } from '@ndla/types-backend/concept-api';
 import { ConceptVisualElementMeta, EmbedMetaData } from '@ndla/types-embed';
-import { IImageMetaInformationV2 } from '@ndla/types-backend/image-api';
+import { IImageMetaInformationV3 } from '@ndla/types-backend/image-api';
 import sortBy from 'lodash/sortBy';
 import { listingUrl } from '../config';
 import {
@@ -41,12 +41,12 @@ const footnoteMetaData = (
   });
 };
 
-const imageMetaData = (data: IImageMetaInformationV2, acc: MetaData) => {
+const imageMetaData = (data: IImageMetaInformationV3, acc: MetaData) => {
   acc['images'] = acc['images'].concat({
     title: data.title.title,
     altText: data.alttext.alttext,
     copyright: data.copyright,
-    src: data.imageUrl,
+    src: data.image.imageUrl,
   });
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,10 +1491,10 @@
   resolved "https://registry.yarnpkg.com/@ndla/types-backend/-/types-backend-0.2.2.tgz#0b80d988c4b15ba1c50c6823e7b3646ee7bc3e9d"
   integrity sha512-h2DLy/1q0caOubE1EHS+UdhMNoqxkjiKdsdad4epTaAeshbwec/XfBi5WFiSUyjaMk9ChkNWg5MJnkI2wXegCQ==
 
-"@ndla/types-embed@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@ndla/types-embed/-/types-embed-1.1.0.tgz#fa31148c6c7e088a74d3206f415894e1c69da215"
-  integrity sha512-iqMswUxOR8Q59MQtbycf6cpPwEFOluvzQgULPCLIHtgkwjhaovynx5s9TQPYN6YVOE/od7FSHr0x7f+REd4aKw==
+"@ndla/types-embed@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@ndla/types-embed/-/types-embed-2.0.0.tgz#1a8372fe8d08e7ce6a3e2720cf13b95c92248b39"
+  integrity sha512-0XzIj8DW8rdMxJnU0bKy7q4YuR01w6wTkVCtuv4eOL6aky9P5YJFaGfwu8b2LdzjtvABqZtclcRRy+CGQGsafQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"


### PR DESCRIPTION
Avhengig av
Endte opp med en irriterende situasjon på de nye ressurs-sidene: Dersom man fikk en 404 på henting av embed ville GQL bare returnert en embed med error-status. Her burde vi jo strengt tatt returnere 404 dersom en embed ikke eksisterer. I løpet av prosessen for å få det til å fungere ordentlig så jeg en grei løsning som kunne forenkle koden noe i embeds-api. Logikken skal være tilnærmet lik, bare at den er flyttet bittelitt. Kan hende at det fortsatt er noen steder der vi er mer feiltolerante enn vi burde være (les: Catcher feil og returnerer null istedenfor). Er dog litt redd for å skrive om disse funksjonene da de brukes andre steder.

Slik fungerer embedsApi nå:
* Ved henting av artikkel er vi så feiltolerante som overhovet mulig. Alle feil catches, og gjøres om til error-embeds.
* Ved henting av enkelt-embeds kaster vi en feil dersom hoveddelen av embeden feiler. Ved henting av underdeler av hovedembeden (f.eks bilde i podcast) ignorerer vi feil.