### PR TITLE
Add an endpoint for fetching a single ndlaembed

### DIFF
--- a/src/api/resourceEmbedApi.ts
+++ b/src/api/resourceEmbedApi.ts
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2023-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {
+  AudioEmbedData,
+  BrightcoveEmbedData,
+  ConceptEmbedData,
+  EmbedData,
+  ImageEmbedData,
+} from '@ndla/types-embed';
+import { load } from 'cheerio';
+import { getEnvironmentVariabel } from '../config';
+import { GQLQueryResourceEmbedArgs, GQLResourceEmbed } from '../types/schema';
+import { getEmbedsFromContent } from '../utils/getEmbedsFromContent';
+import { toArticleMetaData } from '../utils/toArticleMetaData';
+import { transformEmbed } from './embedsApi';
+
+const accountId = getEnvironmentVariabel('BRIGHTCOVE_ACCOUNT_ID', '123456789');
+
+const toEmbed = (
+  id: string,
+  type: string,
+):
+  | BrightcoveEmbedData
+  | ImageEmbedData
+  | AudioEmbedData
+  | ConceptEmbedData
+  | null => {
+  if (type === 'video') {
+    return {
+      resource: 'brightcove',
+      videoid: id,
+      account: accountId,
+      title: '',
+      caption: '',
+      player: 'default',
+    };
+  } else if (type === 'image') {
+    return {
+      resource: 'image',
+      resourceId: id,
+      alt: '',
+    };
+  } else if (type === 'audio') {
+    return {
+      resource: 'audio',
+      resourceId: id,
+      type: 'audio',
+      url: '',
+    };
+  } else if (type === 'concept') {
+    return {
+      resource: 'concept',
+      contentId: id,
+      type: 'block',
+      linkText: '',
+    };
+  } else {
+    return null;
+  }
+};
+
+const attributeRegex = /[A-Z]/g;
+
+export const toHtml = (data: EmbedData): string => {
+  const entries = Object.entries(data ?? {});
+  const dataSet = entries.reduce<string>((acc, [key, value]) => {
+    const newKey = key.replace(attributeRegex, m => `-${m.toLowerCase()}`);
+    return acc.concat(`data-${newKey}="${value.toString()}" `);
+  }, '');
+
+  return `<html><body><ndlaembed ${dataSet}></ndlaembed></body></html>`;
+};
+
+export const fetchResourceEmbed = async (
+  params: GQLQueryResourceEmbedArgs,
+  context: ContextWithLoaders,
+): Promise<GQLResourceEmbed> => {
+  const embed = toEmbed(params.id, params.type);
+  if (!embed) {
+    throw new Error('Unsupported embed');
+  }
+
+  const content = toHtml(embed);
+  const html = load(content, {
+    xmlMode: false,
+    decodeEntities: false,
+  });
+  const embeds = getEmbedsFromContent(html)[0];
+  const embedPromise = await transformEmbed(embeds, context, 0, 0, {
+    shortCircuitOnError: true,
+  });
+
+  const metadata = toArticleMetaData([embedPromise]);
+
+  return {
+    meta: metadata,
+    content: html('body').html() ?? '',
+  };
+};

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -61,7 +61,10 @@ import {
   Query as ImageQuery,
   resolvers as ImageResolvers,
 } from './imageResolvers';
-import { Mutations as TransformArticleMutations } from './transformResolvers';
+import {
+  Query as TransformQuery,
+  Mutations as TransformArticleMutations,
+} from './transformResolvers';
 
 export const resolvers = {
   Query: {
@@ -79,6 +82,7 @@ export const resolvers = {
     ...FolderResolvers,
     ...VideoQuery,
     ...ImageQuery,
+    ...TransformQuery,
   },
   Mutation: {
     ...FolderMutations,

--- a/src/resolvers/transformResolvers.ts
+++ b/src/resolvers/transformResolvers.ts
@@ -7,10 +7,24 @@
  */
 
 import { transformArticle } from '../api/transformArticleApi';
+import { fetchResourceEmbed } from '../api/resourceEmbedApi';
 import {
   GQLMutationResolvers,
+  GQLQueryResolvers,
   GQLMutationTransformArticleContentArgs,
+  GQLQueryResourceEmbedArgs,
+  GQLResourceEmbed,
 } from '../types/schema';
+
+export const Query: Pick<GQLQueryResolvers, 'resourceEmbed'> = {
+  async resourceEmbed(
+    _: any,
+    params: GQLQueryResourceEmbedArgs,
+    context: ContextWithLoaders,
+  ): Promise<GQLResourceEmbed> {
+    return await fetchResourceEmbed(params, context);
+  },
+};
 
 export const Mutations: Pick<
   GQLMutationResolvers,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -404,6 +404,7 @@ export const typeDefs = gql`
     copyright: Copyright!
     copyText: String
     description: String
+    coverPhotoUrl: String
   }
 
   type BrightcoveIframe {
@@ -441,6 +442,8 @@ export const typeDefs = gql`
   type ConceptLicense {
     title: String!
     src: String
+    content: String
+    metaImageUrl: String
     copyright: ConceptCopyright
   }
 
@@ -1042,6 +1045,20 @@ export const typeDefs = gql`
     value: String!
   }
 
+  type ResourceMetaData {
+    images: [ImageLicense!]
+    audios: [AudioLicense!]
+    podcasts: [PodcastLicense!]
+    brightcoves: [BrightcoveLicense!]
+    h5ps: [H5pLicense!]
+    concepts: [ConceptLicense!]
+  }
+
+  type ResourceEmbed {
+    content: String!
+    meta: ResourceMetaData!
+  }
+
   type Query {
     resource(id: String!, subjectId: String, topicId: String): Resource
     article(
@@ -1161,6 +1178,7 @@ export const typeDefs = gql`
     image(id: String!): ImageMetaInformationV2
     brightcoveVideo(id: String!): BrightcoveElement
     examLockStatus: ConfigMetaRestricted!
+    resourceEmbed(id: String!, type: String!): ResourceEmbed!
   }
 
   type Mutation {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -290,7 +290,9 @@ export type GQLConceptFolderResourceMeta = GQLFolderResourceMeta & {
 
 export type GQLConceptLicense = {
   __typename?: 'ConceptLicense';
+  content?: Maybe<Scalars['String']>;
   copyright?: Maybe<GQLConceptCopyright>;
+  metaImageUrl?: Maybe<Scalars['String']>;
   src?: Maybe<Scalars['String']>;
   title: Scalars['String'];
 };
@@ -879,6 +881,7 @@ export type GQLPodcastLicense = {
   __typename?: 'PodcastLicense';
   copyText?: Maybe<Scalars['String']>;
   copyright: GQLCopyright;
+  coverPhotoUrl?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   src: Scalars['String'];
   title: Scalars['String'];
@@ -967,6 +970,7 @@ export type GQLQuery = {
   podcastSeries?: Maybe<GQLPodcastSeriesWithEpisodes>;
   podcastSeriesSearch?: Maybe<GQLPodcastSeriesSearch>;
   resource?: Maybe<GQLResource>;
+  resourceEmbed: GQLResourceEmbed;
   resourceTypes?: Maybe<Array<GQLResourceTypeDefinition>>;
   search?: Maybe<GQLSearch>;
   searchWithoutPagination?: Maybe<GQLSearchWithoutPagination>;
@@ -1132,6 +1136,12 @@ export type GQLQueryResourceArgs = {
 };
 
 
+export type GQLQueryResourceEmbedArgs = {
+  id: Scalars['String'];
+  type: Scalars['String'];
+};
+
+
 export type GQLQuerySearchArgs = {
   aggregatePaths?: InputMaybe<Array<Scalars['String']>>;
   contextFilters?: InputMaybe<Scalars['String']>;
@@ -1243,6 +1253,22 @@ export type GQLResourceArticleArgs = {
   subjectId?: InputMaybe<Scalars['String']>;
 };
 
+export type GQLResourceEmbed = {
+  __typename?: 'ResourceEmbed';
+  content: Scalars['String'];
+  meta: GQLResourceMetaData;
+};
+
+export type GQLResourceMetaData = {
+  __typename?: 'ResourceMetaData';
+  audios?: Maybe<Array<GQLAudioLicense>>;
+  brightcoves?: Maybe<Array<GQLBrightcoveLicense>>;
+  concepts?: Maybe<Array<GQLConceptLicense>>;
+  h5ps?: Maybe<Array<GQLH5pLicense>>;
+  images?: Maybe<Array<GQLImageLicense>>;
+  podcasts?: Maybe<Array<GQLPodcastLicense>>;
+};
+
 export type GQLResourceType = {
   __typename?: 'ResourceType';
   id: Scalars['String'];
@@ -1330,6 +1356,7 @@ export type GQLSharedFolder = {
   __typename?: 'SharedFolder';
   breadcrumbs: Array<GQLBreadcrumb>;
   created: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   id: Scalars['String'];
   name: Scalars['String'];
   parentId?: Maybe<Scalars['String']>;
@@ -1732,6 +1759,8 @@ export type GQLResolversTypes = {
   Reference: ResolverTypeWrapper<GQLReference>;
   RelatedContent: ResolverTypeWrapper<GQLRelatedContent>;
   Resource: ResolverTypeWrapper<GQLResource>;
+  ResourceEmbed: ResolverTypeWrapper<GQLResourceEmbed>;
+  ResourceMetaData: ResolverTypeWrapper<GQLResourceMetaData>;
   ResourceType: ResolverTypeWrapper<GQLResourceType>;
   ResourceTypeDefinition: ResolverTypeWrapper<GQLResourceTypeDefinition>;
   Search: ResolverTypeWrapper<GQLSearch>;
@@ -1864,6 +1893,8 @@ export type GQLResolversParentTypes = {
   Reference: GQLReference;
   RelatedContent: GQLRelatedContent;
   Resource: GQLResource;
+  ResourceEmbed: GQLResourceEmbed;
+  ResourceMetaData: GQLResourceMetaData;
   ResourceType: GQLResourceType;
   ResourceTypeDefinition: GQLResourceTypeDefinition;
   Search: GQLSearch;
@@ -2167,7 +2198,9 @@ export type GQLConceptFolderResourceMetaResolvers<ContextType = any, ParentType 
 };
 
 export type GQLConceptLicenseResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ConceptLicense'] = GQLResolversParentTypes['ConceptLicense']> = {
+  content?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   copyright?: Resolver<Maybe<GQLResolversTypes['ConceptCopyright']>, ParentType, ContextType>;
+  metaImageUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   src?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -2675,6 +2708,7 @@ export type GQLNewFolderResourceResolvers<ContextType = any, ParentType extends 
 export type GQLPodcastLicenseResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['PodcastLicense'] = GQLResolversParentTypes['PodcastLicense']> = {
   copyText?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   copyright?: Resolver<GQLResolversTypes['Copyright'], ParentType, ContextType>;
+  coverPhotoUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   src?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -2764,6 +2798,7 @@ export type GQLQueryResolvers<ContextType = any, ParentType extends GQLResolvers
   podcastSeries?: Resolver<Maybe<GQLResolversTypes['PodcastSeriesWithEpisodes']>, ParentType, ContextType, RequireFields<GQLQueryPodcastSeriesArgs, 'id'>>;
   podcastSeriesSearch?: Resolver<Maybe<GQLResolversTypes['PodcastSeriesSearch']>, ParentType, ContextType, RequireFields<GQLQueryPodcastSeriesSearchArgs, 'page' | 'pageSize'>>;
   resource?: Resolver<Maybe<GQLResolversTypes['Resource']>, ParentType, ContextType, RequireFields<GQLQueryResourceArgs, 'id'>>;
+  resourceEmbed?: Resolver<GQLResolversTypes['ResourceEmbed'], ParentType, ContextType, RequireFields<GQLQueryResourceEmbedArgs, 'id' | 'type'>>;
   resourceTypes?: Resolver<Maybe<Array<GQLResolversTypes['ResourceTypeDefinition']>>, ParentType, ContextType>;
   search?: Resolver<Maybe<GQLResolversTypes['Search']>, ParentType, ContextType, Partial<GQLQuerySearchArgs>>;
   searchWithoutPagination?: Resolver<Maybe<GQLResolversTypes['SearchWithoutPagination']>, ParentType, ContextType, Partial<GQLQuerySearchWithoutPaginationArgs>>;
@@ -2805,6 +2840,22 @@ export type GQLResourceResolvers<ContextType = any, ParentType extends GQLResolv
   relevanceId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   resourceTypes?: Resolver<Maybe<Array<GQLResolversTypes['ResourceType']>>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLResourceEmbedResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ResourceEmbed'] = GQLResolversParentTypes['ResourceEmbed']> = {
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  meta?: Resolver<GQLResolversTypes['ResourceMetaData'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLResourceMetaDataResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ResourceMetaData'] = GQLResolversParentTypes['ResourceMetaData']> = {
+  audios?: Resolver<Maybe<Array<GQLResolversTypes['AudioLicense']>>, ParentType, ContextType>;
+  brightcoves?: Resolver<Maybe<Array<GQLResolversTypes['BrightcoveLicense']>>, ParentType, ContextType>;
+  concepts?: Resolver<Maybe<Array<GQLResolversTypes['ConceptLicense']>>, ParentType, ContextType>;
+  h5ps?: Resolver<Maybe<Array<GQLResolversTypes['H5pLicense']>>, ParentType, ContextType>;
+  images?: Resolver<Maybe<Array<GQLResolversTypes['ImageLicense']>>, ParentType, ContextType>;
+  podcasts?: Resolver<Maybe<Array<GQLResolversTypes['PodcastLicense']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2890,6 +2941,7 @@ export type GQLSearchWithoutPaginationResolvers<ContextType = any, ParentType ex
 export type GQLSharedFolderResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['SharedFolder'] = GQLResolversParentTypes['SharedFolder']> = {
   breadcrumbs?: Resolver<Array<GQLResolversTypes['Breadcrumb']>, ParentType, ContextType>;
   created?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   parentId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -3185,6 +3237,8 @@ export type GQLResolvers<ContextType = any> = {
   Reference?: GQLReferenceResolvers<ContextType>;
   RelatedContent?: GQLRelatedContentResolvers<ContextType>;
   Resource?: GQLResourceResolvers<ContextType>;
+  ResourceEmbed?: GQLResourceEmbedResolvers<ContextType>;
+  ResourceMetaData?: GQLResourceMetaDataResolvers<ContextType>;
   ResourceType?: GQLResourceTypeResolvers<ContextType>;
   ResourceTypeDefinition?: GQLResourceTypeDefinitionResolvers<ContextType>;
   Search?: GQLSearchResolvers<ContextType>;

--- a/src/utils/toArticleMetaData.ts
+++ b/src/utils/toArticleMetaData.ts
@@ -57,6 +57,7 @@ const audioMetaData = ({ data }: Success<'audio'>, acc: MetaData) => {
       copyright: data.copyright,
       src: data.audioFile.url,
       description: data.podcastMeta?.introduction,
+      coverPhotoUrl: data.podcastMeta?.coverPhoto.url,
     });
   } else {
     acc['audios'] = acc['audios'].concat({
@@ -135,6 +136,8 @@ const conceptMetaData = (
     title: concept.title.title,
     copyright: concept.copyright,
     src: `${listingUrl}/concepts/${concept.id}`,
+    content: concept.content?.content ?? '',
+    metaImageUrl: concept.metaImage?.url,
   });
   if (visualElement?.status === 'success') {
     switch (visualElement.resource) {
@@ -169,7 +172,7 @@ interface MetaData {
 
 export const toArticleMetaData = (
   embeds: (EmbedMetaData | undefined)[],
-): GQLArticleMetaData => {
+): Omit<GQLArticleMetaData, '__typename'> => {
   return embeds.reduce<MetaData>(
     (acc, curr) => {
       if (!curr || curr.status === 'error') {


### PR DESCRIPTION
Lager en lite endepunkt som tar inn en `id` og en `type`, som deretter konverteres til en minimal `ndlaembed`. Denne kan konsumeres direkte av `transform` fra article-converter for å fremvise en helt vanlig embed.