### PR TITLE
Fetch all resource-id in regex

### DIFF
--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -89,7 +89,7 @@ export const resolvers = {
       }
 
       const lastResourceMatch = learningpathStep.embedUrl.url
-        .match(/resource(:\d+)?(:\d+)/g)
+        .match(/(resource:[:\da-fA-F-]+)/g)
         ?.pop();
 
       if (lastResourceMatch !== undefined) {


### PR DESCRIPTION
Gammel regex skjønner ikkje resourceid på formatet `urn:resource:2ads:sdf:asdf:sadf` men må ha et tall inni der. Altså `urn:resource:1:2ads:sdf:asdf:sadf`. Dette fikser det problemet.

Eksempel er https://test.ndla.no/subject:1:605d33e0-1695-4540-9255-fc5e612e996f/topic:78ee39df-ab79-4bc6-aeaf-c15cd4d230a1/topic:1:6014f1bf-f63b-4e83-acef-82f5c3283e37/resource:1:178610 som ikkje viser korrekte ikoner for steg 2, mens http://localhost:3000/subject:1:605d33e0-1695-4540-9255-fc5e612e996f/topic:78ee39df-ab79-4bc6-aeaf-c15cd4d230a1/topic:1:6014f1bf-f63b-4e83-acef-82f5c3283e37/resource:1:178610 med lokal graphql funker.