### PR TITLE
Return topic visual element as a full ndlaembed string. Return ndlaembeds for podcastseries

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -65,7 +65,12 @@ const _fetchTransformedArticle = async (
     const subject = params.subjectId;
     const previewH5p = params.previewH5p;
     const article = await fetchSimpleArticle(params.articleId, context);
-    const { content, metaData, visualElement } = await transformArticle(
+    const {
+      content,
+      metaData,
+      visualElement,
+      stringifiedVisualElement,
+    } = await transformArticle(
       article.content.content,
       context,
       article.visualElement?.visualElement,
@@ -84,6 +89,7 @@ const _fetchTransformedArticle = async (
       title: article.title.title,
       metaData,
       tags: article.tags.tags,
+      stringifiedVisualElement,
       content:
         article.articleType === 'standard'
           ? content

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -9,6 +9,7 @@
 import {
   IAudioMetaInformation,
   IAudioSummarySearchResult,
+  ISeries,
 } from '@ndla/types-backend/audio-api';
 import { fetch, resolveJson } from '../utils/apiHelpers';
 
@@ -54,7 +55,7 @@ export async function fetchPodcastsPage(
 export async function fetchPodcastSeries(
   context: Context,
   podcastId: number,
-): Promise<IAudioMetaInformation> {
+): Promise<ISeries> {
   const response = await fetch(
     `/audio-api/v1/series/${podcastId}?language=${context.language}`,
     context,

--- a/src/api/transformArticleApi.ts
+++ b/src/api/transformArticleApi.ts
@@ -153,6 +153,8 @@ export const transformArticle = async (
     }),
   );
   const metaData = toArticleMetaData(embedPromises);
+  const visualElementCheerio = visEl?.('body') ?? embeds[0].embed;
+  const transformedVisEl = visualElementCheerio.html();
   const transformedContent = html('body').html();
   const visualElementMeta =
     visEl || (visualElement && showVisualElement)
@@ -167,5 +169,6 @@ export const transformArticle = async (
     metaData,
     content: transformedContent,
     visualElement: transformedVisualElement,
+    stringifiedVisualElement: transformedVisEl,
   };
 };

--- a/src/api/transformArticleApi.ts
+++ b/src/api/transformArticleApi.ts
@@ -154,7 +154,7 @@ export const transformArticle = async (
   );
   const metaData = toArticleMetaData(embedPromises);
   const visualElementCheerio = visEl?.('body') ?? embeds[0].embed;
-  const transformedVisEl = visualElementCheerio.html();
+  const transformedVisEl = visualElementCheerio?.html();
   const transformedContent = html('body').html();
   const visualElementMeta =
     visEl || (visualElement && showVisualElement)
@@ -169,6 +169,10 @@ export const transformArticle = async (
     metaData,
     content: transformedContent,
     visualElement: transformedVisualElement,
-    stringifiedVisualElement: transformedVisEl,
+    visualElementEmbed: !!transformedVisEl &&
+      !!visualElementMeta && {
+        content: transformedVisEl,
+        meta: toArticleMetaData([visualElementMeta]),
+      },
   };
 };

--- a/src/resolvers/transformResolvers.ts
+++ b/src/resolvers/transformResolvers.ts
@@ -7,22 +7,36 @@
  */
 
 import { transformArticle } from '../api/transformArticleApi';
-import { fetchResourceEmbed } from '../api/resourceEmbedApi';
+import {
+  fetchResourceEmbed,
+  fetchResourceEmbeds,
+} from '../api/resourceEmbedApi';
 import {
   GQLMutationResolvers,
   GQLQueryResolvers,
   GQLMutationTransformArticleContentArgs,
   GQLQueryResourceEmbedArgs,
   GQLResourceEmbed,
+  GQLQueryResourceEmbedsArgs,
 } from '../types/schema';
 
-export const Query: Pick<GQLQueryResolvers, 'resourceEmbed'> = {
+export const Query: Pick<
+  GQLQueryResolvers,
+  'resourceEmbed' | 'resourceEmbeds'
+> = {
   async resourceEmbed(
     _: any,
     params: GQLQueryResourceEmbedArgs,
     context: ContextWithLoaders,
   ): Promise<GQLResourceEmbed> {
     return await fetchResourceEmbed(params, context);
+  },
+  async resourceEmbeds(
+    _: any,
+    params: GQLQueryResourceEmbedsArgs,
+    context: ContextWithLoaders,
+  ): Promise<GQLResourceEmbed> {
+    return await fetchResourceEmbeds(params, context);
   },
 };
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -515,6 +515,7 @@ export const typeDefs = gql`
     relatedContent: [RelatedContent!]
     availability: String
     revisionDate: String
+    stringifiedVisualElement: String
   }
 
   type EmbedVisualelement {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -133,6 +133,7 @@ export const typeDefs = gql`
     episodes: [Audio!]
     coverPhoto: CoverPhoto!
     hasRSS: Boolean!
+    content: ResourceEmbed
   }
 
   type AudioSummary {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -515,7 +515,7 @@ export const typeDefs = gql`
     relatedContent: [RelatedContent!]
     availability: String
     revisionDate: String
-    stringifiedVisualElement: String
+    visualElementEmbed: ResourceEmbed
   }
 
   type EmbedVisualelement {
@@ -1111,6 +1111,12 @@ export const typeDefs = gql`
     meta: ResourceMetaData!
   }
 
+  input ResourceEmbedInput {
+    id: String!
+    type: String!
+    conceptType: String
+  }
+
   type Query {
     resource(id: String!, subjectId: String, topicId: String): Resource
     article(
@@ -1235,6 +1241,7 @@ export const typeDefs = gql`
     image(id: String!): ImageMetaInformationV2
     examLockStatus: ConfigMetaRestricted!
     resourceEmbed(id: String!, type: String!): ResourceEmbed!
+    resourceEmbeds(resources: [ResourceEmbedInput!]!): ResourceEmbed!
   }
 
   type Mutation {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -958,6 +958,7 @@ export type GQLPodcastSeriesSummary = {
 
 export type GQLPodcastSeriesWithEpisodes = GQLPodcastSeriesBase & {
   __typename?: 'PodcastSeriesWithEpisodes';
+  content?: Maybe<GQLResourceEmbed>;
   coverPhoto: GQLCoverPhoto;
   description: GQLDescription;
   episodes?: Maybe<Array<GQLAudio>>;
@@ -2848,6 +2849,7 @@ export type GQLPodcastSeriesSummaryResolvers<ContextType = any, ParentType exten
 };
 
 export type GQLPodcastSeriesWithEpisodesResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['PodcastSeriesWithEpisodes'] = GQLResolversParentTypes['PodcastSeriesWithEpisodes']> = {
+  content?: Resolver<Maybe<GQLResolversTypes['ResourceEmbed']>, ParentType, ContextType>;
   coverPhoto?: Resolver<GQLResolversTypes['CoverPhoto'], ParentType, ContextType>;
   description?: Resolver<GQLResolversTypes['Description'], ParentType, ContextType>;
   episodes?: Resolver<Maybe<Array<GQLResolversTypes['Audio']>>, ParentType, ContextType>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -49,6 +49,7 @@ export type GQLArticle = {
   revision: Scalars['Int'];
   revisionDate?: Maybe<Scalars['String']>;
   slug?: Maybe<Scalars['String']>;
+  stringifiedVisualElement?: Maybe<Scalars['String']>;
   supportedLanguages?: Maybe<Array<Scalars['String']>>;
   tags?: Maybe<Array<Scalars['String']>>;
   title: Scalars['String'];
@@ -2009,6 +2010,7 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
   revision?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   revisionDate?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  stringifiedVisualElement?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   tags?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -49,12 +49,12 @@ export type GQLArticle = {
   revision: Scalars['Int'];
   revisionDate?: Maybe<Scalars['String']>;
   slug?: Maybe<Scalars['String']>;
-  stringifiedVisualElement?: Maybe<Scalars['String']>;
   supportedLanguages?: Maybe<Array<Scalars['String']>>;
   tags?: Maybe<Array<Scalars['String']>>;
   title: Scalars['String'];
   updated: Scalars['String'];
   visualElement?: Maybe<GQLVisualElement>;
+  visualElementEmbed?: Maybe<GQLResourceEmbed>;
 };
 
 
@@ -1011,6 +1011,7 @@ export type GQLQuery = {
   programmes?: Maybe<Array<GQLProgrammePage>>;
   resource?: Maybe<GQLResource>;
   resourceEmbed: GQLResourceEmbed;
+  resourceEmbeds: GQLResourceEmbed;
   resourceTypes?: Maybe<Array<GQLResourceTypeDefinition>>;
   search?: Maybe<GQLSearch>;
   searchWithoutPagination?: Maybe<GQLSearchWithoutPagination>;
@@ -1184,6 +1185,11 @@ export type GQLQueryResourceEmbedArgs = {
 };
 
 
+export type GQLQueryResourceEmbedsArgs = {
+  resources: Array<GQLResourceEmbedInput>;
+};
+
+
 export type GQLQuerySearchArgs = {
   aggregatePaths?: InputMaybe<Array<Scalars['String']>>;
   contextFilters?: InputMaybe<Scalars['String']>;
@@ -1302,6 +1308,12 @@ export type GQLResourceEmbed = {
   __typename?: 'ResourceEmbed';
   content: Scalars['String'];
   meta: GQLResourceMetaData;
+};
+
+export type GQLResourceEmbedInput = {
+  conceptType?: InputMaybe<Scalars['String']>;
+  id: Scalars['String'];
+  type: Scalars['String'];
 };
 
 export type GQLResourceMetaData = {
@@ -1803,6 +1815,7 @@ export type GQLResolversTypes = {
   RelatedContent: ResolverTypeWrapper<GQLRelatedContent>;
   Resource: ResolverTypeWrapper<GQLResource>;
   ResourceEmbed: ResolverTypeWrapper<GQLResourceEmbed>;
+  ResourceEmbedInput: GQLResourceEmbedInput;
   ResourceMetaData: ResolverTypeWrapper<GQLResourceMetaData>;
   ResourceType: ResolverTypeWrapper<GQLResourceType>;
   ResourceTypeDefinition: ResolverTypeWrapper<GQLResourceTypeDefinition>;
@@ -1941,6 +1954,7 @@ export type GQLResolversParentTypes = {
   RelatedContent: GQLRelatedContent;
   Resource: GQLResource;
   ResourceEmbed: GQLResourceEmbed;
+  ResourceEmbedInput: GQLResourceEmbedInput;
   ResourceMetaData: GQLResourceMetaData;
   ResourceType: GQLResourceType;
   ResourceTypeDefinition: GQLResourceTypeDefinition;
@@ -2010,12 +2024,12 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
   revision?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   revisionDate?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
-  stringifiedVisualElement?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   tags?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   updated?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   visualElement?: Resolver<Maybe<GQLResolversTypes['VisualElement']>, ParentType, ContextType>;
+  visualElementEmbed?: Resolver<Maybe<GQLResolversTypes['ResourceEmbed']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -2887,6 +2901,7 @@ export type GQLQueryResolvers<ContextType = any, ParentType extends GQLResolvers
   programmes?: Resolver<Maybe<Array<GQLResolversTypes['ProgrammePage']>>, ParentType, ContextType>;
   resource?: Resolver<Maybe<GQLResolversTypes['Resource']>, ParentType, ContextType, RequireFields<GQLQueryResourceArgs, 'id'>>;
   resourceEmbed?: Resolver<GQLResolversTypes['ResourceEmbed'], ParentType, ContextType, RequireFields<GQLQueryResourceEmbedArgs, 'id' | 'type'>>;
+  resourceEmbeds?: Resolver<GQLResolversTypes['ResourceEmbed'], ParentType, ContextType, RequireFields<GQLQueryResourceEmbedsArgs, 'resources'>>;
   resourceTypes?: Resolver<Maybe<Array<GQLResolversTypes['ResourceTypeDefinition']>>, ParentType, ContextType>;
   search?: Resolver<Maybe<GQLResolversTypes['Search']>, ParentType, ContextType, Partial<GQLQuerySearchArgs>>;
   searchWithoutPagination?: Resolver<Maybe<GQLResolversTypes['SearchWithoutPagination']>, ParentType, ContextType, Partial<GQLQuerySearchWithoutPaginationArgs>>;


### PR DESCRIPTION
Legger inn støtte for å returnere en `<ndlaembed />` med ferdig utfylt `data-json`, slik at visuelle elementer på emner kan konsumere den direkte. Legger også inn støtte for å hente ut `<ndlaembed />`s på podcastseries v.h.a en resolver, som lar oss gå over til nye audio-embeds på serie-siden. Dette er ikke en like effektiv metode som tidligere, men det er ikke nevneverdig langt unna heller.

Fikser delvis https://github.com/NDLANO/Issues/issues/3621