### PR TITLE
Use another type for standard display

### DIFF
--- a/src/api/resourceEmbedApi.ts
+++ b/src/api/resourceEmbedApi.ts
@@ -63,7 +63,7 @@ const toEmbed = ({
     return {
       resource: 'concept',
       contentId: id,
-      type: (conceptType ?? 'block') as 'block' | 'inline' | 'notion',
+      type: (conceptType ?? 'notion') as 'block' | 'inline' | 'notion',
       linkText: '',
     };
   } else {


### PR DESCRIPTION
Fixes NDLANO/Issues#3633

Endrer standardvisninga slik at forklaringsside får forklaring uten modal.