### PR TITLE
Highlight code blocks with prism

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.21",
     "lru-cache": "^4.1.3",
     "node-fetch": "2.6.7",
+    "prismjs": "^1.29.0",
     "query-string": "^6.2.0"
   },
   "devDependencies": {
@@ -69,6 +70,7 @@
     "@types/lru-cache": "^4.1.1",
     "@types/node": "^18.11.15",
     "@types/node-fetch": "^2.1.2",
+    "@types/prismjs": "^1.26.0",
     "@types/query-string": "^6.1.1",
     "@types/serve-static": "1.13.10",
     "@vercel/ncc": "^0.34.0",

--- a/src/api/embedsApi.ts
+++ b/src/api/embedsApi.ts
@@ -50,6 +50,7 @@ import { fetchSimpleArticle } from './articleApi';
 import { fetchEmbedConcept, fetchEmbedConcepts } from './conceptApi';
 import { checkIfFileExists } from './fileApi';
 import { getBrightcoveCopyright } from '../utils/brightcoveUtils';
+import highlightCode from '../utils/highlightCode';
 
 type Fetch<T extends EmbedMetaData, ExtraData = {}> = (
   params: {
@@ -132,7 +133,8 @@ const h5pMeta: Fetch<H5pMetaData> = async ({ embedData, context, opts }) => {
 
 const codeMeta: Fetch<CodeMetaData> = async ({ embedData }) => {
   const decodedContent = he.decode(embedData.codeContent);
-  return { decodedContent };
+  const highlighted = highlightCode(decodedContent, embedData.codeFormat);
+  return { decodedContent, highlightedCode: highlighted };
 };
 
 export interface TransformOptions {

--- a/src/utils/highlightCode.ts
+++ b/src/utils/highlightCode.ts
@@ -1,0 +1,15 @@
+import Prism from 'prismjs';
+import loadLanguages from 'prismjs/components/index';
+
+loadLanguages();
+
+const highlightCode = (code: string, language: string) => {
+  const highlighted = Prism.highlight(
+    code,
+    Prism.languages[language],
+    language,
+  );
+  return highlighted;
+};
+
+export default highlightCode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,6 +1861,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
   integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
 
+"@types/prismjs@^1.26.0":
+  version "1.26.0"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.26.0.tgz#a1c3809b0ad61c62cac6d4e0c56d610c910b7654"
+  integrity sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==
+
 "@types/qs@*":
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.4.tgz#a59e851c1ba16c0513ea123830dd639a0a15cb6a"
@@ -6611,6 +6616,11 @@ pretty-format@^29.0.0, pretty-format@^29.0.3:
     "@jest/schemas" "^29.0.0"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+prismjs@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/3662
Avhengig av https://github.com/NDLANO/frontend-packages/pull/1812

Flytter ansvaret for å highlight kode over til graphql-api. Dette fører til at vi hverken trenger `react-syntax-highlighter` eller `prismjs` som en direkte avhengighet i `@ndla/code`. Konsekvensen av dette er at vi må legge inn en lignende kodesnutt i ED for å sørge for at syntax-highlighting ikke brekker der.