### PR TITLE
Markdown fixes

### DIFF
--- a/src/api/uptimeApi.ts
+++ b/src/api/uptimeApi.ts
@@ -47,7 +47,6 @@ export async function fetchUptimeIssues(
       closable: !issue.labels?.find(label => label.name === 'permanent'),
       body: parseMarkdown({
         markdown: he.decode(issue.body).replace(/<[^>]*>?/gm, ''),
-        inline: true,
       }),
     };
   });

--- a/src/utils/parseMarkdown.ts
+++ b/src/utils/parseMarkdown.ts
@@ -70,8 +70,8 @@ interface ParseOptions {
 
 const parseMarkdown = ({ markdown, inline }: ParseOptions) => {
   const html = (inline
-    ? marked.parseInline(markdown)
-    : marked.parse(markdown)) as string;
+    ? marked.parseInline(markdown.trim())
+    : marked.parse(markdown.trim())) as string;
   const sanitizedHtml = sanitizeHtml(html);
   return sanitizedHtml;
 };


### PR DESCRIPTION
Denne inneholder to små, men viktige, endringer. 

* `parseMarkdown` trimmer nå alltid innholdet den skal parse. Dette fikser en feil som forårsaket at noen captions ble vist selv om de ikke inneholdt noe.
* Markdown fra uptime (GitHub) rendres ikke lenger som inline. Vi kunne strengt tatt fortsatt med dette, men frontend-packages har lagt opp til at dette er block-markdown.