### PR TITLE
Add an empty summary in details that do not already have a summary

### DIFF
--- a/src/api/transformArticleApi.ts
+++ b/src/api/transformArticleApi.ts
@@ -123,6 +123,11 @@ export const transformArticle = async (
   html('h2').each((_, el) => {
     html(el).attr('data-text', html(el).text());
   });
+  html('details').each((_, el) => {
+    if (!el.children.some(c => c.type === 'tag' && c.name === 'summary')) {
+      html(el).prepend('<summary></summary>');
+    }
+  });
   if (showVisualElement && visualElement) {
     html('body').prepend(`<section>${visualElement}</section>`);
   }


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/3560
Fikset den originalt i frontend-packages, men bedre hvis vi kan gjøre det på server. 
Denne kan testes ved å kjøre ed med lokal graphql. Det går bare an å gjenskape situasjonen i html-editoren, vanlig skjema legger automatisk inn tom summary.