### PR TITLE
Add mutations to create new topic, and reply to topic

### DIFF
--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -15,6 +15,7 @@ import {
   fetchArenaTopicsByUser,
   fetchCsrfTokenForSession,
   newTopic,
+  replyToTopic,
 } from '../api/arenaApi';
 import {
   GQLArenaCategory,
@@ -26,6 +27,7 @@ import {
   GQLQueryArenaTopicsByUserArgs,
   GQLQueryResolvers,
   GQLMutationResolvers,
+  GQLArenaPost,
 } from '../types/schema';
 
 export const Query: Pick<
@@ -81,12 +83,22 @@ export const Query: Pick<
   },
 };
 
-export const Mutations: Pick<GQLMutationResolvers, 'newArenaTopic'> = {
+export const Mutations: Pick<
+  GQLMutationResolvers,
+  'newArenaTopic' | 'replyToTopic'
+> = {
   async newArenaTopic(
     _: any,
     params,
     context: ContextWithLoaders,
   ): Promise<GQLArenaTopic> {
     return newTopic(params, context);
+  },
+  async replyToTopic(
+    _: any,
+    params,
+    context: ContextWithLoaders,
+  ): Promise<GQLArenaPost> {
+    return replyToTopic(params, context);
   },
 };

--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -13,6 +13,8 @@ import {
   fetchArenaUser,
   fetchArenaTopic,
   fetchArenaTopicsByUser,
+  fetchCsrfTokenForSession,
+  newTopic,
 } from '../api/arenaApi';
 import {
   GQLArenaCategory,
@@ -23,6 +25,7 @@ import {
   GQLQueryArenaTopicArgs,
   GQLQueryArenaTopicsByUserArgs,
   GQLQueryResolvers,
+  GQLMutationResolvers,
 } from '../types/schema';
 
 export const Query: Pick<
@@ -75,5 +78,15 @@ export const Query: Pick<
     context: ContextWithLoaders,
   ): Promise<GQLArenaTopic[]> {
     return fetchArenaTopicsByUser(params, context);
+  },
+};
+
+export const Mutations: Pick<GQLMutationResolvers, 'newArenaTopic'> = {
+  async newArenaTopic(
+    _: any,
+    params,
+    context: ContextWithLoaders,
+  ): Promise<GQLArenaTopic> {
+    return newTopic(params, context);
   },
 };

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -69,7 +69,10 @@ import {
   resolvers as ProgrammeResolvers,
 } from './programmeResolvers';
 
-import { Query as ArenaQuery } from './arenaResolvers';
+import {
+  Query as ArenaQuery,
+  Mutations as ArenaMutations,
+} from './arenaResolvers';
 
 export const resolvers = {
   Query: {
@@ -93,6 +96,7 @@ export const resolvers = {
   Mutation: {
     ...FolderMutations,
     ...TransformArticleMutations,
+    ...ArenaMutations,
   },
   ...folderResolvers,
   ...articleResolvers,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1393,6 +1393,11 @@ export const typeDefs = gql`
       draftConcept: Boolean
       absoluteUrl: Boolean
     ): String!
+    newArenaTopic(
+      categoryId: Int!
+      title: String!
+      content: String!
+    ): ArenaTopic!
   }
 `;
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1398,6 +1398,7 @@ export const typeDefs = gql`
       title: String!
       content: String!
     ): ArenaTopic!
+    replyToTopic(topicId: Int!, content: String!): ArenaPost!
   }
 `;
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -877,6 +877,7 @@ export type GQLMutation = {
   deleteFolderResource: Scalars['String'];
   deletePersonalData: Scalars['Boolean'];
   newArenaTopic: GQLArenaTopic;
+  replyToTopic: GQLArenaPost;
   sortFolders: GQLSortResult;
   sortResources: GQLSortResult;
   transformArticleContent: Scalars['String'];
@@ -925,6 +926,12 @@ export type GQLMutationNewArenaTopicArgs = {
   categoryId: Scalars['Int'];
   content: Scalars['String'];
   title: Scalars['String'];
+};
+
+
+export type GQLMutationReplyToTopicArgs = {
+  content: Scalars['String'];
+  topicId: Scalars['Int'];
 };
 
 
@@ -3027,6 +3034,7 @@ export type GQLMutationResolvers<ContextType = any, ParentType extends GQLResolv
   deleteFolderResource?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationDeleteFolderResourceArgs, 'folderId' | 'resourceId'>>;
   deletePersonalData?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
   newArenaTopic?: Resolver<GQLResolversTypes['ArenaTopic'], ParentType, ContextType, RequireFields<GQLMutationNewArenaTopicArgs, 'categoryId' | 'content' | 'title'>>;
+  replyToTopic?: Resolver<GQLResolversTypes['ArenaPost'], ParentType, ContextType, RequireFields<GQLMutationReplyToTopicArgs, 'content' | 'topicId'>>;
   sortFolders?: Resolver<GQLResolversTypes['SortResult'], ParentType, ContextType, RequireFields<GQLMutationSortFoldersArgs, 'sortedIds'>>;
   sortResources?: Resolver<GQLResolversTypes['SortResult'], ParentType, ContextType, RequireFields<GQLMutationSortResourcesArgs, 'parentId' | 'sortedIds'>>;
   transformArticleContent?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationTransformArticleContentArgs, 'content'>>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -876,6 +876,7 @@ export type GQLMutation = {
   deleteFolder: Scalars['String'];
   deleteFolderResource: Scalars['String'];
   deletePersonalData: Scalars['Boolean'];
+  newArenaTopic: GQLArenaTopic;
   sortFolders: GQLSortResult;
   sortResources: GQLSortResult;
   transformArticleContent: Scalars['String'];
@@ -917,6 +918,13 @@ export type GQLMutationDeleteFolderArgs = {
 export type GQLMutationDeleteFolderResourceArgs = {
   folderId: Scalars['String'];
   resourceId: Scalars['String'];
+};
+
+
+export type GQLMutationNewArenaTopicArgs = {
+  categoryId: Scalars['Int'];
+  content: Scalars['String'];
+  title: Scalars['String'];
 };
 
 
@@ -2221,7 +2229,7 @@ export type GQLArenaTopicResolvers<ContextType = any, ParentType extends GQLReso
 
 export type GQLArenaUserResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ArenaUser'] = GQLResolversParentTypes['ArenaUser']> = {
   displayName?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  groupTitleArray?: Resolver<Maybe<Array<Maybe<GQLResolversTypes['String']>>>, ParentType, ContextType>;
+  groupTitleArray?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   profilePicture?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   slug?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -3018,6 +3026,7 @@ export type GQLMutationResolvers<ContextType = any, ParentType extends GQLResolv
   deleteFolder?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationDeleteFolderArgs, 'id'>>;
   deleteFolderResource?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationDeleteFolderResourceArgs, 'folderId' | 'resourceId'>>;
   deletePersonalData?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  newArenaTopic?: Resolver<GQLResolversTypes['ArenaTopic'], ParentType, ContextType, RequireFields<GQLMutationNewArenaTopicArgs, 'categoryId' | 'content' | 'title'>>;
   sortFolders?: Resolver<GQLResolversTypes['SortResult'], ParentType, ContextType, RequireFields<GQLMutationSortFoldersArgs, 'sortedIds'>>;
   sortResources?: Resolver<GQLResolversTypes['SortResult'], ParentType, ContextType, RequireFields<GQLMutationSortResourcesArgs, 'parentId' | 'sortedIds'>>;
   transformArticleContent?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationTransformArticleContentArgs, 'content'>>;


### PR DESCRIPTION
Tenkte først jeg skulle prøve å omgå at vi gjør ekstra requests til nodebb, men det viser seg å kreve en del håndtering i frontenden uansett, så gjør en mellomting.


Dvs at dersom man ikke sender med både cookie og `x-csrf-token` header så vil vi gjøre en request for å hente csrf-token fra config-endepunktet i nodebb, som vi bruker sammen med cookien for å gjøre requesten. Dersom de kommer med så vil vi bruke eksisterende cookie/csrf-token/session.

Gjør det enkelt for frontenden å slippe å tenke på csrf i første omgang, men ser for meg at en bedre løsning vil være å faktisk håndtere csrf/cookies/session i frontenden selv.