### PR TITLE
Added graphql support for deletion and editing of topic and posts

### DIFF
--- a/src/api/arenaApi.ts
+++ b/src/api/arenaApi.ts
@@ -6,14 +6,18 @@
  *
  */
 
+import { isContext } from 'vm';
 import {
   GQLArenaCategory,
   GQLArenaNotification,
   GQLArenaPost,
   GQLArenaTopic,
   GQLArenaUser,
+  GQLMutationDeletePostArgs,
+  GQLMutationDeleteTopicArgs,
   GQLMutationNewArenaTopicArgs,
   GQLMutationReplyToTopicArgs,
+  GQLMutationUpdatePostArgs,
   GQLQueryArenaCategoryArgs,
   GQLQueryArenaTopicArgs,
   GQLQueryArenaTopicsByUserArgs,
@@ -224,4 +228,64 @@ export const replyToTopic = async (
   });
   const resolved = await resolveJson(response);
   return toArenaPost(resolved.response, undefined);
+};
+
+export const deletePost = async (
+  { postId }: GQLMutationDeletePostArgs,
+  context: Context,
+) => {
+  const csrfHeaders = await fetchCsrfTokenForSession(context);
+  const response = await fetch(
+    `/groups/api/v3/posts/${postId}/state`,
+    context,
+    {
+      method: 'DELETE',
+      headers: {
+        'content-type': 'application/json',
+        ...csrfHeaders,
+      },
+    },
+  );
+  const resolved = await resolveJson(response);
+  return resolved.status.code === 'ok';
+};
+
+export const deleteTopic = async (
+  { topicId }: GQLMutationDeleteTopicArgs,
+  context: Context,
+) => {
+  const csrfHeaders = await fetchCsrfTokenForSession(context);
+  const response = await fetch(
+    `/groups/api/v3/topics/${topicId}/state`,
+    context,
+    {
+      method: 'DELETE',
+      headers: {
+        'content-type': 'application/json',
+        ...csrfHeaders,
+      },
+    },
+  );
+  const resolved = await resolveJson(response);
+  return resolved.status.code === 'ok';
+};
+
+export const updatePost = async (
+  { postId, content, title }: GQLMutationUpdatePostArgs,
+  context: Context,
+) => {
+  const csrfHeaders = await fetchCsrfTokenForSession(context);
+  const response = await fetch(`/groups/api/v3/posts/${postId}`, context, {
+    method: 'PUT',
+    headers: {
+      'content-type': 'application/json',
+      ...csrfHeaders,
+    },
+    body: JSON.stringify({
+      content,
+      title,
+    }),
+  });
+  const resolved = await resolveJson(response);
+  return toArenaPost(resolved.response);
 };

--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -16,6 +16,9 @@ import {
   fetchArenaNotifications,
   newTopic,
   replyToTopic,
+  deletePost,
+  deleteTopic,
+  updatePost,
 } from '../api/arenaApi';
 import {
   GQLArenaCategory,
@@ -32,6 +35,9 @@ import {
   GQLArenaPost,
   GQLMutationReplyToTopicArgs,
   GQLArenaUser,
+  GQLMutationDeletePostArgs,
+  GQLMutationDeleteTopicArgs,
+  GQLMutationUpdatePostArgs,
 } from '../types/schema';
 
 export const Query: Pick<
@@ -97,7 +103,12 @@ export const Query: Pick<
 
 export const Mutations: Pick<
   GQLMutationResolvers,
-  'newArenaTopic' | 'replyToTopic' | 'markNotificationAsRead'
+  | 'newArenaTopic'
+  | 'replyToTopic'
+  | 'markNotificationAsRead'
+  | 'deletePost'
+  | 'deleteTopic'
+  | 'updatePost'
 > = {
   async newArenaTopic(
     _: any,
@@ -122,5 +133,26 @@ export const Mutations: Pick<
       params.topicIds.map(topicId => fetchArenaTopic({ topicId }, context)),
     );
     return params.topicIds;
+  },
+  async deletePost(
+    _: any,
+    params: GQLMutationDeletePostArgs,
+    context: Context,
+  ) {
+    return await deletePost(params, context);
+  },
+  async deleteTopic(
+    _: any,
+    params: GQLMutationDeleteTopicArgs,
+    context: Context,
+  ) {
+    return await deleteTopic(params, context);
+  },
+  async updatePost(
+    _: any,
+    params: GQLMutationUpdatePostArgs,
+    context: Context,
+  ) {
+    return await updatePost(params, context);
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1431,6 +1431,9 @@ export const typeDefs = gql`
       content: String!
     ): ArenaTopic!
     replyToTopic(topicId: Int!, content: String!): ArenaPost!
+    updatePost(postId: Int!, content: String!, title: String): ArenaPost!
+    deletePost(postId: Int!): Boolean!
+    deleteTopic(topicId: Int!): Boolean!
   }
 `;
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -898,6 +898,8 @@ export type GQLMutation = {
   deleteFolder: Scalars['String'];
   deleteFolderResource: Scalars['String'];
   deletePersonalData: Scalars['Boolean'];
+  deletePost: Scalars['Boolean'];
+  deleteTopic: Scalars['Boolean'];
   markNotificationAsRead: Array<Scalars['Int']>;
   newArenaTopic: GQLArenaTopic;
   replyToTopic: GQLArenaPost;
@@ -908,6 +910,7 @@ export type GQLMutation = {
   updateFolderResource: GQLFolderResource;
   updateFolderStatus: Array<Scalars['String']>;
   updatePersonalData: GQLMyNdlaPersonalData;
+  updatePost: GQLArenaPost;
 };
 
 
@@ -942,6 +945,16 @@ export type GQLMutationDeleteFolderArgs = {
 export type GQLMutationDeleteFolderResourceArgs = {
   folderId: Scalars['String'];
   resourceId: Scalars['String'];
+};
+
+
+export type GQLMutationDeletePostArgs = {
+  postId: Scalars['Int'];
+};
+
+
+export type GQLMutationDeleteTopicArgs = {
+  topicId: Scalars['Int'];
 };
 
 
@@ -1008,6 +1021,13 @@ export type GQLMutationUpdateFolderStatusArgs = {
 export type GQLMutationUpdatePersonalDataArgs = {
   favoriteSubjects?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   shareName?: InputMaybe<Scalars['Boolean']>;
+};
+
+
+export type GQLMutationUpdatePostArgs = {
+  content: Scalars['String'];
+  postId: Scalars['Int'];
+  title?: InputMaybe<Scalars['String']>;
 };
 
 export type GQLMyNdlaPersonalData = {
@@ -3096,6 +3116,8 @@ export type GQLMutationResolvers<ContextType = any, ParentType extends GQLResolv
   deleteFolder?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationDeleteFolderArgs, 'id'>>;
   deleteFolderResource?: Resolver<GQLResolversTypes['String'], ParentType, ContextType, RequireFields<GQLMutationDeleteFolderResourceArgs, 'folderId' | 'resourceId'>>;
   deletePersonalData?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
+  deletePost?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationDeletePostArgs, 'postId'>>;
+  deleteTopic?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType, RequireFields<GQLMutationDeleteTopicArgs, 'topicId'>>;
   markNotificationAsRead?: Resolver<Array<GQLResolversTypes['Int']>, ParentType, ContextType, RequireFields<GQLMutationMarkNotificationAsReadArgs, 'topicIds'>>;
   newArenaTopic?: Resolver<GQLResolversTypes['ArenaTopic'], ParentType, ContextType, RequireFields<GQLMutationNewArenaTopicArgs, 'categoryId' | 'content' | 'title'>>;
   replyToTopic?: Resolver<GQLResolversTypes['ArenaPost'], ParentType, ContextType, RequireFields<GQLMutationReplyToTopicArgs, 'content' | 'topicId'>>;
@@ -3106,6 +3128,7 @@ export type GQLMutationResolvers<ContextType = any, ParentType extends GQLResolv
   updateFolderResource?: Resolver<GQLResolversTypes['FolderResource'], ParentType, ContextType, RequireFields<GQLMutationUpdateFolderResourceArgs, 'id'>>;
   updateFolderStatus?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType, RequireFields<GQLMutationUpdateFolderStatusArgs, 'folderId' | 'status'>>;
   updatePersonalData?: Resolver<GQLResolversTypes['MyNdlaPersonalData'], ParentType, ContextType, Partial<GQLMutationUpdatePersonalDataArgs>>;
+  updatePost?: Resolver<GQLResolversTypes['ArenaPost'], ParentType, ContextType, RequireFields<GQLMutationUpdatePostArgs, 'content' | 'postId'>>;
 };
 
 export type GQLMyNdlaPersonalDataResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['MyNdlaPersonalData'] = GQLResolversParentTypes['MyNdlaPersonalData']> = {


### PR DESCRIPTION
La til støtte for delete og update av topic of posts.
Topic og posts bruker samme endepunkt for å oppdatere seg, nodebb håndterer ikke `title` objektet om det ikke er en `mainPost`