### PR TITLE
Mark notification as read with mark read endpoint

### DIFF
--- a/src/api/arenaApi.ts
+++ b/src/api/arenaApi.ts
@@ -186,6 +186,15 @@ export const fetchArenaTopic = async (
   return toTopic(resolved);
 };
 
+export const markNotificationRead = async (tid: number, context: Context) => {
+  const csrfHeaders = await fetchCsrfTokenForSession(context);
+  await fetch(
+    `/groups/api/v3/topics/${tid}/read`,
+    { ...context, shouldUseCache: false },
+    { headers: csrfHeaders, method: 'PUT' },
+  );
+};
+
 export const fetchArenaRecentTopics = async (
   context: Context,
 ): Promise<GQLArenaTopic[]> => {

--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -22,6 +22,7 @@ import {
   newFlag,
   subscribeToTopic,
   unsubscribeFromTopic,
+  markNotificationRead,
 } from '../api/arenaApi';
 import {
   GQLArenaCategory,
@@ -136,7 +137,7 @@ export const Mutations: Pick<
     context: Context,
   ) {
     await Promise.all(
-      params.topicIds.map(topicId => fetchArenaTopic({ topicId }, context)),
+      params?.topicIds?.map(topicId => markNotificationRead(topicId, context)),
     );
     return params.topicIds;
   },


### PR DESCRIPTION
Endepunktet funka ikke for meg før men fungerer nå.... 
Denne vil også markere sletta innlegg som lest, så det vil fungere mykje betre enn metoden som er i bruk akkurat nå.