### PR TITLE
Added status check on arena topic fetch

### DIFF
--- a/src/api/arenaApi.ts
+++ b/src/api/arenaApi.ts
@@ -182,8 +182,16 @@ export const fetchArenaTopic = async (
     { ...context, shouldUseCache: false },
     { headers: csrfHeaders },
   );
+
   const resolved = await resolveJson(response);
-  return toTopic(resolved);
+
+  if (resolved.ok) {
+    return toTopic(resolved);
+  } else {
+    throw new GraphQLError(resolved.status.message, {
+      extensions: { status: response.status },
+    });
+  }
 };
 
 export const fetchArenaRecentTopics = async (


### PR DESCRIPTION
Trenger statusen for å se om et topic er gyldig eller ikke når det skal displayes. Topics som er deleted vil returnere 403 og deleted topics sine notifikasjoner blir ikke slettet så må håndteres på frontenden.