### PR TITLE
Do not use Github markdown

### DIFF
--- a/src/utils/parseMarkdown.ts
+++ b/src/utils/parseMarkdown.ts
@@ -60,6 +60,7 @@ const subscriptPlugin: TokenizerAndRendererExtension = {
 
 const marked = new Marked({
   async: false,
+  gfm: false,
   extensions: [subscriptPlugin, superscriptPlugin],
 });
 


### PR DESCRIPTION
Fixes https://trello.com/c/wEBMrNBR/673-frontend-gjer-om-mailto-til-https

Lenker må heller kodes som riktig markdown