### PR TITLE
Replace metaimage-url with url from image-api

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,6 +6,8 @@
  *
  */
 
+export { fetchArticle, fetchArticles } from "./articleApi";
+export { searchConcepts, fetchConcept, fetchListingPage } from "./conceptApi";
 export {
   fetchCompetenceGoals,
   fetchCompetenceSet,
@@ -17,9 +19,11 @@ export {
   fetchLK20Curriculum,
   fetchLK20CompetenceGoalSet,
 } from "./curriculumApi";
+export { fetchImage, fetchImageV3 } from "./imageApi";
 export { fetchFrontpage, fetchSubjectPage, fetchFilmFrontpage, fetchMovieMeta } from "./frontpageApi";
-export { fetchArticle, fetchArticles } from "./articleApi";
 export { fetchLearningpaths, fetchLearningpath } from "./learningpathApi";
+export { fetchOembed } from "./oembedApi";
+export { search, groupSearch, frontpageSearch, searchWithoutPagination } from "./searchApi";
 export {
   fetchResourceTypes,
   fetchSubjectTopics,
@@ -32,7 +36,4 @@ export {
   queryContexts,
   queryNodes,
 } from "./taxonomyApi";
-export { search, groupSearch, frontpageSearch, searchWithoutPagination } from "./searchApi";
-export { fetchOembed } from "./oembedApi";
-export { searchConcepts, fetchConcept, fetchListingPage } from "./conceptApi";
 export { fetchUptimeIssues } from "./uptimeApi";

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -13,6 +13,7 @@ import {
   fetchCompetenceGoals,
   fetchCoreElements,
   fetchCrossSubjectTopicsByCode,
+  fetchImageV3,
   fetchSubjectTopics,
   searchConcepts,
 } from "../api";
@@ -22,6 +23,7 @@ import {
   GQLCompetenceGoal,
   GQLCoreElement,
   GQLCrossSubjectElement,
+  GQLMetaImage,
   GQLQueryArticleArgs,
 } from "../types/schema";
 import parseMarkdown from "../utils/parseMarkdown";
@@ -83,6 +85,16 @@ export const resolvers = {
         return results.concepts;
       }
       return [];
+    },
+    async metaImage(article: GQLArticle, _: any, context: ContextWithLoaders): Promise<GQLMetaImage> {
+      if (article.metaImage) {
+        const imageId = article.metaImage.url.split("/").pop() ?? "";
+        const image = await fetchImageV3(imageId, context);
+        return {
+          ...article.metaImage,
+          url: image.image.imageUrl,
+        };
+      }
     },
     introduction(article: GQLArticle): string {
       return parseMarkdown({


### PR DESCRIPTION
Fixes NDLANO/Issues#3947

Facebook klager over at vi bruker bildeurl uten filending for metabilder. Dette henter ordentlig bilde med url fra image-api.