### PR TITLE
Fetch less data when fetching an article

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -123,7 +123,7 @@ export async function fetchArticles(articleIds: string[], context: Context): Pro
 
   const requests = [];
   if (numberOfPages) {
-    for (let i = 0; i <= numberOfPages; i += 1) {
+    for (let i = 0; i < numberOfPages; i += 1) {
       requests.push(fetchArticlesPage(ids, context, pageSize, i));
     }
   }

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -9,87 +9,56 @@
 import { IArticleV2 } from "@ndla/types-backend/article-api";
 import { queryNodes } from "./taxonomyApi";
 import { transformArticle } from "./transformArticleApi";
-import { localConverter, ndlaUrl } from "../config";
-import { GQLArticle, GQLMeta } from "../types/schema";
+import { ndlaUrl } from "../config";
+import {
+  GQLArticleTransformedContentArgs,
+  GQLMeta,
+  GQLRelatedContent,
+  GQLTransformedArticleContent,
+} from "../types/schema";
 import { fetch, resolveJson } from "../utils/apiHelpers";
 import { getArticleIdFromUrn, findPrimaryPath } from "../utils/articleHelpers";
-import { parseVisualElement } from "../utils/visualelementHelpers";
 
 interface ArticleParams {
-  convertEmbeds?: boolean;
   articleId: string;
-  subjectId?: string;
-  isOembed?: string;
-  showVisualElement?: string;
-  path?: string;
-  previewH5p?: boolean;
-  draftConcept?: boolean;
-  absoluteUrl?: boolean;
 }
 
-const _fetchTransformedArticle = async (params: ArticleParams, context: Context) => {
-  if (!params.convertEmbeds) {
-    const host = localConverter ? "http://localhost:3100" : "";
-    const subjectParam = params.subjectId ? `&subject=${params.subjectId}` : "";
-    const oembedParam = params.isOembed ? `&isOembed=${params.isOembed}` : "";
-    const visualElementParam = params.showVisualElement ? `&showVisualElement=${params.showVisualElement}` : "";
-    const pathParam = params.path ? `&path=${params.path}` : "";
-    const res = await fetch(
-      `${host}/article-converter/json/${context.language}/${params.articleId}?1=1${subjectParam}${oembedParam}${pathParam}${visualElementParam}`,
-      context,
-    ).then(resolveJson);
+export const fetchTransformedContent = async (
+  article: IArticleV2,
+  _params: GQLArticleTransformedContentArgs,
+  context: Context,
+): Promise<GQLTransformedArticleContent> => {
+  const params = _params.transformArgs ?? {};
+  const subject = params.subjectId;
+  const previewH5p = params.previewH5p;
+  const { content, metaData, visualElement, visualElementEmbed } = await transformArticle(
+    article.content.content,
+    context,
+    article.visualElement?.visualElement,
+    {
+      subject,
+      draftConcept: params.draftConcept,
+      previewH5p,
+      absoluteUrl: params.absoluteUrl,
+      showVisualElement: params.showVisualElement === "true",
+    },
+  );
 
-    if (res.visualElement) {
-      try {
-        res.visualElement = {
-          ...(await parseVisualElement(res.visualElement.visualElement, context)),
-          embed: res.visualElement.visualElement,
-          language: res.visualElement.language,
-        };
-      } catch (e) {
-        res.visualElement = undefined;
-      }
-    }
-
-    return res;
-  } else {
-    const subject = params.subjectId;
-    const previewH5p = params.previewH5p;
-    const article = await fetchSimpleArticle(params.articleId, context);
-    const { content, metaData, visualElement, visualElementEmbed } = await transformArticle(
-      article.content.content,
-      context,
-      article.visualElement?.visualElement,
-      {
-        subject,
-        draftConcept: params.draftConcept,
-        previewH5p,
-        absoluteUrl: params.absoluteUrl,
-        showVisualElement: params.showVisualElement === "true",
-      },
-    );
-    return {
-      ...article,
-      introduction: article.introduction?.introduction ?? "",
-      htmlIntroduction: article.introduction?.htmlIntroduction ?? "",
-      metaDescription: article.metaDescription.metaDescription,
-      title: article.title.title,
-      htmlTitle: article.title.htmlTitle,
-      metaData,
-      tags: article.tags.tags,
-      visualElementEmbed,
-      content: article.articleType === "standard" ? content : content === "<section></section>" ? "" : content,
-      visualElement,
-      language: article.content.language,
-    };
-  }
+  return {
+    content: (article.articleType === "standard" ? content : content === "<section></section>" ? "" : content) ?? "",
+    metaData,
+    visualElement,
+    visualElementEmbed: visualElementEmbed,
+  };
 };
 
-export async function fetchArticle(params: ArticleParams, context: Context): Promise<GQLArticle> {
-  const article = await _fetchTransformedArticle(params, context);
-
-  const nullableRelatedContent = await Promise.all(
-    article?.relatedContent?.map(async (rc: any) => {
+export async function fetchRelatedContent(
+  article: IArticleV2,
+  params: { subjectId?: string },
+  context: Context,
+): Promise<GQLRelatedContent[]> {
+  const nullableRelatedContent: (GQLRelatedContent | undefined)[] = await Promise.all(
+    article?.relatedContent?.map(async (rc) => {
       if (typeof rc !== "number") {
         return {
           title: rc.title,
@@ -125,11 +94,12 @@ export async function fetchArticle(params: ArticleParams, context: Context): Pro
     }),
   );
   const relatedContent = nullableRelatedContent.filter((rc: any) => !!rc);
+  return relatedContent as GQLRelatedContent[];
+}
 
-  return {
-    ...article,
-    relatedContent: relatedContent ?? [],
-  };
+export async function fetchArticle(params: ArticleParams, context: Context): Promise<IArticleV2> {
+  const article = await fetchSimpleArticle(params.articleId, context);
+  return article;
 }
 
 export async function fetchArticlesPage(

--- a/src/api/transformArticleApi.ts
+++ b/src/api/transformArticleApi.ts
@@ -158,10 +158,12 @@ export const transformArticle = async (
     metaData,
     content: transformedContent,
     visualElement: transformedVisualElement,
-    visualElementEmbed: !!transformedVisEl &&
-      !!visualElementMeta && {
-        content: transformedVisEl,
-        meta: toArticleMetaData([visualElementMeta]),
-      },
+    visualElementEmbed:
+      !!transformedVisEl && !!visualElementMeta
+        ? {
+            content: transformedVisEl,
+            meta: toArticleMetaData([visualElementMeta]),
+          }
+        : undefined,
   };
 };

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -8,9 +8,11 @@
 
 // @ts-strict-ignore
 
+import cheerio from "cheerio";
 import { IArticleV2 } from "@ndla/types-backend/article-api";
 import {
   fetchArticle,
+  fetchOembed,
   fetchCompetenceGoals,
   fetchCoreElements,
   fetchCrossSubjectTopicsByCode,
@@ -20,6 +22,7 @@ import {
 } from "../api";
 import { fetchTransformedContent, fetchRelatedContent } from "../api/articleApi";
 import { Concept } from "../api/conceptApi";
+import { ndlaUrl } from "../config";
 import {
   GQLCompetenceGoal,
   GQLCoreElement,
@@ -29,6 +32,7 @@ import {
   GQLTransformedArticleContent,
   GQLArticleTransformedContentArgs,
   GQLRelatedContent,
+  GQLVisualElementOembed,
 } from "../types/schema";
 import parseMarkdown from "../utils/parseMarkdown";
 
@@ -78,6 +82,12 @@ export const resolvers = {
         return results.concepts;
       }
       return [];
+    },
+    async oembed(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<string | undefined> {
+      return fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}/article/${article.id}`, context).then((oembed) => {
+        const parsed = cheerio.load(oembed.html);
+        return parsed("iframe").attr("src");
+      });
     },
     async metaImage(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<GQLMetaImage | undefined> {
       if (article.metaImage) {

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -8,6 +8,7 @@
 
 // @ts-strict-ignore
 
+import { IArticleV2 } from "@ndla/types-backend/article-api";
 import {
   fetchArticle,
   fetchCompetenceGoals,
@@ -17,33 +18,25 @@ import {
   fetchSubjectTopics,
   searchConcepts,
 } from "../api";
+import { fetchTransformedContent, fetchRelatedContent } from "../api/articleApi";
 import { Concept } from "../api/conceptApi";
 import {
-  GQLArticle,
   GQLCompetenceGoal,
   GQLCoreElement,
   GQLCrossSubjectElement,
   GQLMetaImage,
   GQLQueryArticleArgs,
+  GQLTransformedArticleContent,
+  GQLArticleTransformedContentArgs,
+  GQLRelatedContent,
 } from "../types/schema";
 import parseMarkdown from "../utils/parseMarkdown";
 
 export const Query = {
-  async article(
-    _: any,
-    { id, subjectId, isOembed, path, absoluteUrl, draftConcept, showVisualElement, convertEmbeds }: GQLQueryArticleArgs,
-    context: ContextWithLoaders,
-  ): Promise<GQLArticle> {
+  async article(_: any, { id }: GQLQueryArticleArgs, context: ContextWithLoaders): Promise<IArticleV2> {
     return fetchArticle(
       {
         articleId: id,
-        subjectId,
-        absoluteUrl,
-        draftConcept,
-        isOembed,
-        path,
-        showVisualElement,
-        convertEmbeds,
       },
       context,
     );
@@ -52,18 +45,18 @@ export const Query = {
 
 export const resolvers = {
   Article: {
-    async competenceGoals(article: GQLArticle, _: any, context: ContextWithLoaders): Promise<GQLCompetenceGoal[]> {
+    async competenceGoals(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<GQLCompetenceGoal[]> {
       const language =
         article.supportedLanguages.find((lang) => lang === context.language) || article.supportedLanguages[0];
       return fetchCompetenceGoals(article.grepCodes, language, context);
     },
-    async coreElements(article: GQLArticle, _: any, context: ContextWithLoaders): Promise<GQLCoreElement[]> {
+    async coreElements(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<GQLCoreElement[]> {
       const language =
         article.supportedLanguages.find((lang) => lang === context.language) || article.supportedLanguages[0];
       return fetchCoreElements(article.grepCodes, language, context);
     },
     async crossSubjectTopics(
-      article: GQLArticle,
+      article: IArticleV2,
       args: { subjectId: string },
       context: ContextWithLoaders,
     ): Promise<GQLCrossSubjectElement[]> {
@@ -79,14 +72,14 @@ export const resolvers = {
         path: topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title)?.path,
       }));
     },
-    async concepts(article: GQLArticle, _: any, context: ContextWithLoaders): Promise<Concept[]> {
+    async concepts(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<Concept[]> {
       if (article?.conceptIds && article.conceptIds.length > 0) {
         const results = await searchConcepts({ ids: article.conceptIds }, context);
         return results.concepts;
       }
       return [];
     },
-    async metaImage(article: GQLArticle, _: any, context: ContextWithLoaders): Promise<GQLMetaImage> {
+    async metaImage(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<GQLMetaImage | undefined> {
       if (article.metaImage) {
         const imageId = article.metaImage.url.split("/").pop() ?? "";
         const image = await fetchImageV3(imageId, context);
@@ -96,11 +89,43 @@ export const resolvers = {
         };
       }
     },
-    introduction(article: GQLArticle): string {
+    introduction(article: IArticleV2): string {
       return parseMarkdown({
-        markdown: article.htmlIntroduction ?? "",
+        markdown: article.introduction?.htmlIntroduction ?? "",
         inline: true,
       });
+    },
+    htmlIntroduction(article: IArticleV2): string {
+      return article.introduction?.htmlIntroduction ?? "";
+    },
+    metaDescription(article: IArticleV2): string {
+      return article.metaDescription.metaDescription;
+    },
+    title(article: IArticleV2): string {
+      return article.title.title;
+    },
+    htmlTitle(article: IArticleV2): string {
+      return article.title.htmlTitle;
+    },
+    tags(article: IArticleV2): string[] {
+      return article.tags.tags;
+    },
+    language(article: IArticleV2): string {
+      return article.content.language;
+    },
+    async transformedContent(
+      article: IArticleV2,
+      args: GQLArticleTransformedContentArgs,
+      context: ContextWithLoaders,
+    ): Promise<GQLTransformedArticleContent> {
+      return fetchTransformedContent(article, args, context);
+    },
+    async relatedContent(
+      article: IArticleV2,
+      args: { subjectId?: string },
+      context: ContextWithLoaders,
+    ): Promise<GQLRelatedContent[]> {
+      return fetchRelatedContent(article, args, context);
     },
   },
 };

--- a/src/resolvers/frontpageResolvers.ts
+++ b/src/resolvers/frontpageResolvers.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { IArticleV2 } from "@ndla/types-backend/article-api";
 import {
   IFrontPage,
   ISubjectPageData,
@@ -38,8 +39,8 @@ export const Query = {
 
 export const resolvers = {
   FrontpageMenu: {
-    async article(menu: IFrontPage, _: any, context: ContextWithLoaders): Promise<GQLArticle> {
-      return fetchArticle({ articleId: `${menu.articleId}`, convertEmbeds: true }, context);
+    async article(menu: IFrontPage, _: any, context: ContextWithLoaders): Promise<IArticleV2> {
+      return fetchArticle({ articleId: `${menu.articleId}` }, context);
     },
     async hideLevel(menu: IFrontPage | IMenu, _: any, context: ContextWithLoaders): Promise<boolean> {
       return "hideLevel" in menu ? menu.hideLevel : false;
@@ -85,12 +86,11 @@ export const resolvers = {
   },
 
   FilmFrontpage: {
-    async article(frontpage: IFilmFrontPageData, _: any, context: ContextWithLoaders): Promise<GQLArticle | undefined> {
+    async article(frontpage: IFilmFrontPageData, _: any, context: ContextWithLoaders): Promise<IArticleV2 | undefined> {
       if (frontpage.article) {
         return fetchArticle(
           {
             articleId: `${getArticleIdFromUrn(frontpage.article)}`,
-            convertEmbeds: true,
           },
           context,
         );

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -8,11 +8,9 @@
 
 // @ts-strict-ignore
 
-import cheerio from "cheerio";
 import { IArticleV2 } from "@ndla/types-backend/article-api";
-import { fetchNode, fetchResourceTypes, fetchArticle, fetchLearningpath, fetchOembed } from "../api";
+import { fetchNode, fetchResourceTypes, fetchArticle, fetchLearningpath } from "../api";
 import { fetchNodeByContentUri } from "../api/taxonomyApi";
-import { ndlaUrl } from "../config";
 import {
   GQLLearningpath,
   GQLMeta,
@@ -22,7 +20,6 @@ import {
   GQLResourceType,
   GQLResourceTypeDefinition,
   GQLTaxonomyContext,
-  GQLVisualElementOembed,
 } from "../types/schema";
 import { getArticleIdFromUrn, getLearningpathIdFromUrn } from "../utils/articleHelpers";
 
@@ -119,13 +116,6 @@ export const resolvers = {
       }
       throw Object.assign(new Error("Missing learningpath contentUri for resource with id: " + resource.id), {
         status: 404,
-      });
-    },
-    async oembed(resource: GQLResource, _: any, context: ContextWithLoaders): Promise<string | undefined> {
-      if (!resource.contentUri?.startsWith("urn:article")) return undefined;
-      return fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}${resource.path}`, context).then((oembed) => {
-        const parsed = cheerio.load(oembed.html);
-        return parsed("iframe").attr("src");
       });
     },
     async article(resource: GQLResource, _: any, context: ContextWithLoaders): Promise<IArticleV2> {

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -8,17 +8,16 @@
 
 // @ts-strict-ignore
 
+import { IArticleV2 } from "@ndla/types-backend/article-api";
 import { Node } from "@ndla/types-taxonomy";
 import { fetchArticle, fetchNode, fetchNodeResources, fetchChildren, fetchOembed, queryNodes } from "../api";
 import { ndlaUrl } from "../config";
 import {
-  GQLArticle,
   GQLMeta,
   GQLQueryTopicArgs,
   GQLQueryTopicsArgs,
   GQLResource,
   GQLTopic,
-  GQLTopicArticleArgs,
   GQLTopicCoreResourcesArgs,
   GQLTopicSupplementaryResourcesArgs,
   GQLVisualElementOembed,
@@ -59,32 +58,23 @@ export const Query = {
 
 export const resolvers = {
   Topic: {
-    async availability(topic: Node, _: GQLTopicArticleArgs, context: ContextWithLoaders) {
+    async availability(topic: Node, _: any, context: ContextWithLoaders) {
       const article = await context.loaders.articlesLoader.load(getArticleIdFromUrn(topic.contentUri));
       return article.availability;
     },
-    async article(topic: Node, args: GQLTopicArticleArgs, context: ContextWithLoaders): Promise<GQLArticle> {
+    async oembed(topic: Node, _: any, context: ContextWithLoaders): Promise<string | undefined> {
       if (topic.contentUri && topic.contentUri.startsWith("urn:article")) {
         const articleId = getArticleIdFromUrn(topic.contentUri);
-        return Promise.resolve(
-          fetchArticle(
-            {
-              articleId,
-              subjectId: args.subjectId,
-              showVisualElement: args.showVisualElement,
-              convertEmbeds: args.convertEmbeds,
-              path: topic.path,
-            },
-            context,
-          ).then((article) => {
-            const path = topic.path || `/article/${articleId}`;
-            return Object.assign({}, article, {
-              oembed: fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}${path}`, context).then(
-                (oembed) => oembed.html.split('"')[3],
-              ),
-            });
-          }),
+        const path = topic.path || `/article/${articleId}`;
+        return fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}${path}`, context).then(
+          (oembed) => oembed.html?.split('"')[3],
         );
+      }
+    },
+    async article(topic: Node, _: any, context: ContextWithLoaders): Promise<IArticleV2> {
+      if (topic.contentUri && topic.contentUri.startsWith("urn:article")) {
+        const articleId = getArticleIdFromUrn(topic.contentUri);
+        return fetchArticle({ articleId }, context);
       }
       throw Object.assign(new Error("Missing article contentUri for topic with id: " + topic.id), { status: 404 });
     },

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -10,8 +10,7 @@
 
 import { IArticleV2 } from "@ndla/types-backend/article-api";
 import { Node } from "@ndla/types-taxonomy";
-import { fetchArticle, fetchNode, fetchNodeResources, fetchChildren, fetchOembed, queryNodes } from "../api";
-import { ndlaUrl } from "../config";
+import { fetchArticle, fetchNode, fetchNodeResources, fetchChildren, queryNodes } from "../api";
 import {
   GQLMeta,
   GQLQueryTopicArgs,
@@ -20,7 +19,6 @@ import {
   GQLTopic,
   GQLTopicCoreResourcesArgs,
   GQLTopicSupplementaryResourcesArgs,
-  GQLVisualElementOembed,
 } from "../types/schema";
 import { nodeToTaxonomyEntity } from "../utils/apiHelpers";
 import { filterMissingArticles, getArticleIdFromUrn } from "../utils/articleHelpers";
@@ -61,15 +59,6 @@ export const resolvers = {
     async availability(topic: Node, _: any, context: ContextWithLoaders) {
       const article = await context.loaders.articlesLoader.load(getArticleIdFromUrn(topic.contentUri));
       return article.availability;
-    },
-    async oembed(topic: Node, _: any, context: ContextWithLoaders): Promise<string | undefined> {
-      if (topic.contentUri && topic.contentUri.startsWith("urn:article")) {
-        const articleId = getArticleIdFromUrn(topic.contentUri);
-        const path = topic.path || `/article/${articleId}`;
-        return fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}${path}`, context).then(
-          (oembed) => oembed.html?.split('"')[3],
-        );
-      }
     },
     async article(topic: Node, _: any, context: ContextWithLoaders): Promise<IArticleV2> {
       if (topic.contentUri && topic.contentUri.startsWith("urn:article")) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -312,8 +312,9 @@ export const typeDefs = gql`
     parents: [Topic!]
     meta: Meta
     learningpath: Learningpath
-    article(subjectId: String, isOembed: String, convertEmbeds: Boolean): Article
+    article: Article
     availability: String
+    oembed: String
   }
 
   type TaxonomyContext {
@@ -337,7 +338,7 @@ export const typeDefs = gql`
     url: String
     language: String
     meta: Meta
-    article(subjectId: String, showVisualElement: String, convertEmbeds: Boolean): Article
+    article: Article
     availability: String
     isPrimary: Boolean
     parent: String
@@ -347,6 +348,7 @@ export const typeDefs = gql`
     coreResources(subjectId: String): [Resource!]
     supplementaryResources(subjectId: String): [Resource!]
     alternateTopics: [Topic!]
+    oembed: String
   }
 
   type License {
@@ -517,13 +519,11 @@ export const typeDefs = gql`
     created: String!
     updated: String!
     published: String!
-    visualElement: VisualElement
     metaImage: MetaImage
     metaDescription: String!
     articleType: String!
     oldNdlaUrl: String
     requiredLibraries: [ArticleRequiredLibrary!]
-    metaData: ArticleMetaData
     supportedLanguages: [String!]
     copyright: Copyright!
     tags: [String!]
@@ -531,14 +531,30 @@ export const typeDefs = gql`
     competenceGoals: [CompetenceGoal!]
     coreElements: [CoreElement!]
     crossSubjectTopics(subjectId: String): [CrossSubjectElement!]
-    oembed: String
     conceptIds: [Int!]
     concepts: [Concept!]
-    relatedContent: [RelatedContent!]
+    relatedContent(subjectId: String): [RelatedContent!]
     availability: String
     revisionDate: String
-    visualElementEmbed: ResourceEmbed
     language: String!
+    transformedContent(transformArgs: TransformedArticleContentInput): TransformedArticleContent!
+  }
+
+  input TransformedArticleContentInput {
+    subjectId: String
+    isOembed: String
+    showVisualElement: String
+    path: String
+    previewH5p: Boolean
+    draftConcept: Boolean
+    absoluteUrl: Boolean
+  }
+
+  type TransformedArticleContent {
+    content: String!
+    visualElement: VisualElement
+    metaData: ArticleMetaData
+    visualElementEmbed: ResourceEmbed
   }
 
   type EmbedVisualelement {
@@ -1338,16 +1354,7 @@ export const typeDefs = gql`
   type Query {
     resource(id: String!, subjectId: String, topicId: String): Resource
     articleResource(articleId: String, taxonomyId: String): Resource
-    article(
-      id: String!
-      subjectId: String
-      isOembed: String
-      draftConcept: Boolean
-      absoluteUrl: Boolean
-      path: String
-      showVisualElement: String
-      convertEmbeds: Boolean
-    ): Article
+    article(id: String!): Article
     subject(id: String!): Subject
     subjectpage(id: Int!): SubjectPage
     filmfrontpage: FilmFrontpage

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -314,7 +314,6 @@ export const typeDefs = gql`
     learningpath: Learningpath
     article: Article
     availability: String
-    oembed: String
   }
 
   type TaxonomyContext {
@@ -348,7 +347,6 @@ export const typeDefs = gql`
     coreResources(subjectId: String): [Resource!]
     supplementaryResources(subjectId: String): [Resource!]
     alternateTopics: [Topic!]
-    oembed: String
   }
 
   type License {
@@ -538,6 +536,7 @@ export const typeDefs = gql`
     revisionDate: String
     language: String!
     transformedContent(transformArgs: TransformedArticleContentInput): TransformedArticleContent!
+    oembed: String
   }
 
   input TransformedArticleContentInput {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -195,6 +195,7 @@ export type GQLArticle = {
   language: Scalars['String'];
   metaDescription: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
+  oembed?: Maybe<Scalars['String']>;
   oldNdlaUrl?: Maybe<Scalars['String']>;
   published: Scalars['String'];
   relatedContent?: Maybe<Array<GQLRelatedContent>>;
@@ -1817,7 +1818,6 @@ export type GQLResource = GQLTaxonomyEntity & GQLWithArticle & {
   meta?: Maybe<GQLMeta>;
   metadata: GQLTaxonomyMetadata;
   name: Scalars['String'];
-  oembed?: Maybe<Scalars['String']>;
   parents?: Maybe<Array<GQLTopic>>;
   path: Scalars['String'];
   paths: Array<Scalars['String']>;
@@ -2095,7 +2095,6 @@ export type GQLTopic = GQLTaxonomyEntity & GQLWithArticle & {
   meta?: Maybe<GQLMeta>;
   metadata: GQLTaxonomyMetadata;
   name: Scalars['String'];
-  oembed?: Maybe<Scalars['String']>;
   parent?: Maybe<Scalars['String']>;
   parentId?: Maybe<Scalars['String']>;
   path: Scalars['String'];
@@ -2761,6 +2760,7 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
   language?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   oldNdlaUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   published?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   relatedContent?: Resolver<Maybe<Array<GQLResolversTypes['RelatedContent']>>, ParentType, ContextType, Partial<GQLArticleRelatedContentArgs>>;
@@ -3803,7 +3803,6 @@ export type GQLResourceResolvers<ContextType = any, ParentType extends GQLResolv
   meta?: Resolver<Maybe<GQLResolversTypes['Meta']>, ParentType, ContextType>;
   metadata?: Resolver<GQLResolversTypes['TaxonomyMetadata'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parents?: Resolver<Maybe<Array<GQLResolversTypes['Topic']>>, ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   paths?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -4071,7 +4070,6 @@ export type GQLTopicResolvers<ContextType = any, ParentType extends GQLResolvers
   meta?: Resolver<Maybe<GQLResolversTypes['Meta']>, ParentType, ContextType>;
   metadata?: Resolver<GQLResolversTypes['TaxonomyMetadata'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parent?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parentId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -193,10 +193,8 @@ export type GQLArticle = {
   id: Scalars['Int'];
   introduction?: Maybe<Scalars['String']>;
   language: Scalars['String'];
-  metaData?: Maybe<GQLArticleMetaData>;
   metaDescription: Scalars['String'];
   metaImage?: Maybe<GQLMetaImage>;
-  oembed?: Maybe<Scalars['String']>;
   oldNdlaUrl?: Maybe<Scalars['String']>;
   published: Scalars['String'];
   relatedContent?: Maybe<Array<GQLRelatedContent>>;
@@ -207,14 +205,23 @@ export type GQLArticle = {
   supportedLanguages?: Maybe<Array<Scalars['String']>>;
   tags?: Maybe<Array<Scalars['String']>>;
   title: Scalars['String'];
+  transformedContent: GQLTransformedArticleContent;
   updated: Scalars['String'];
-  visualElement?: Maybe<GQLVisualElement>;
-  visualElementEmbed?: Maybe<GQLResourceEmbed>;
 };
 
 
 export type GQLArticleCrossSubjectTopicsArgs = {
   subjectId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type GQLArticleRelatedContentArgs = {
+  subjectId?: InputMaybe<Scalars['String']>;
+};
+
+
+export type GQLArticleTransformedContentArgs = {
+  transformArgs?: InputMaybe<GQLTransformedArticleContentInput>;
 };
 
 export type GQLArticleFolderResourceMeta = GQLFolderResourceMeta & {
@@ -1550,14 +1557,7 @@ export type GQLQueryArenaUserV2Args = {
 
 
 export type GQLQueryArticleArgs = {
-  absoluteUrl?: InputMaybe<Scalars['Boolean']>;
-  convertEmbeds?: InputMaybe<Scalars['Boolean']>;
-  draftConcept?: InputMaybe<Scalars['Boolean']>;
   id: Scalars['String'];
-  isOembed?: InputMaybe<Scalars['String']>;
-  path?: InputMaybe<Scalars['String']>;
-  showVisualElement?: InputMaybe<Scalars['String']>;
-  subjectId?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1817,6 +1817,7 @@ export type GQLResource = GQLTaxonomyEntity & GQLWithArticle & {
   meta?: Maybe<GQLMeta>;
   metadata: GQLTaxonomyMetadata;
   name: Scalars['String'];
+  oembed?: Maybe<Scalars['String']>;
   parents?: Maybe<Array<GQLTopic>>;
   path: Scalars['String'];
   paths: Array<Scalars['String']>;
@@ -1825,13 +1826,6 @@ export type GQLResource = GQLTaxonomyEntity & GQLWithArticle & {
   resourceTypes?: Maybe<Array<GQLResourceType>>;
   supportedLanguages: Array<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
-};
-
-
-export type GQLResourceArticleArgs = {
-  convertEmbeds?: InputMaybe<Scalars['Boolean']>;
-  isOembed?: InputMaybe<Scalars['String']>;
-  subjectId?: InputMaybe<Scalars['String']>;
 };
 
 export type GQLResourceEmbed = {
@@ -2101,6 +2095,7 @@ export type GQLTopic = GQLTaxonomyEntity & GQLWithArticle & {
   meta?: Maybe<GQLMeta>;
   metadata: GQLTaxonomyMetadata;
   name: Scalars['String'];
+  oembed?: Maybe<Scalars['String']>;
   parent?: Maybe<Scalars['String']>;
   parentId?: Maybe<Scalars['String']>;
   path: Scalars['String'];
@@ -2112,13 +2107,6 @@ export type GQLTopic = GQLTaxonomyEntity & GQLWithArticle & {
   supplementaryResources?: Maybe<Array<GQLResource>>;
   supportedLanguages: Array<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
-};
-
-
-export type GQLTopicArticleArgs = {
-  convertEmbeds?: InputMaybe<Scalars['Boolean']>;
-  showVisualElement?: InputMaybe<Scalars['String']>;
-  subjectId?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -2135,6 +2123,24 @@ export type GQLTranscription = {
   __typename?: 'Transcription';
   pinyin?: Maybe<Scalars['String']>;
   traditional?: Maybe<Scalars['String']>;
+};
+
+export type GQLTransformedArticleContent = {
+  __typename?: 'TransformedArticleContent';
+  content: Scalars['String'];
+  metaData?: Maybe<GQLArticleMetaData>;
+  visualElement?: Maybe<GQLVisualElement>;
+  visualElementEmbed?: Maybe<GQLResourceEmbed>;
+};
+
+export type GQLTransformedArticleContentInput = {
+  absoluteUrl?: InputMaybe<Scalars['Boolean']>;
+  draftConcept?: InputMaybe<Scalars['Boolean']>;
+  isOembed?: InputMaybe<Scalars['String']>;
+  path?: InputMaybe<Scalars['String']>;
+  previewH5p?: InputMaybe<Scalars['Boolean']>;
+  showVisualElement?: InputMaybe<Scalars['String']>;
+  subjectId?: InputMaybe<Scalars['String']>;
 };
 
 export type GQLUpdatedFolder = {
@@ -2410,6 +2416,8 @@ export type GQLResolversTypes = {
   Title: ResolverTypeWrapper<GQLTitle>;
   Topic: ResolverTypeWrapper<GQLTopic>;
   Transcription: ResolverTypeWrapper<GQLTranscription>;
+  TransformedArticleContent: ResolverTypeWrapper<GQLTransformedArticleContent>;
+  TransformedArticleContentInput: GQLTransformedArticleContentInput;
   UpdatedFolder: ResolverTypeWrapper<GQLUpdatedFolder>;
   UpdatedFolderResource: ResolverTypeWrapper<GQLUpdatedFolderResource>;
   UptimeAlert: ResolverTypeWrapper<GQLUptimeAlert>;
@@ -2570,6 +2578,8 @@ export type GQLResolversParentTypes = {
   Title: GQLTitle;
   Topic: GQLTopic;
   Transcription: GQLTranscription;
+  TransformedArticleContent: GQLTransformedArticleContent;
+  TransformedArticleContentInput: GQLTransformedArticleContentInput;
   UpdatedFolder: GQLUpdatedFolder;
   UpdatedFolderResource: GQLUpdatedFolderResource;
   UptimeAlert: GQLUptimeAlert;
@@ -2749,13 +2759,11 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
   id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   introduction?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   language?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  metaData?: Resolver<Maybe<GQLResolversTypes['ArticleMetaData']>, ParentType, ContextType>;
   metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
-  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   oldNdlaUrl?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   published?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  relatedContent?: Resolver<Maybe<Array<GQLResolversTypes['RelatedContent']>>, ParentType, ContextType>;
+  relatedContent?: Resolver<Maybe<Array<GQLResolversTypes['RelatedContent']>>, ParentType, ContextType, Partial<GQLArticleRelatedContentArgs>>;
   requiredLibraries?: Resolver<Maybe<Array<GQLResolversTypes['ArticleRequiredLibrary']>>, ParentType, ContextType>;
   revision?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   revisionDate?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -2763,9 +2771,8 @@ export type GQLArticleResolvers<ContextType = any, ParentType extends GQLResolve
   supportedLanguages?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   tags?: Resolver<Maybe<Array<GQLResolversTypes['String']>>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  transformedContent?: Resolver<GQLResolversTypes['TransformedArticleContent'], ParentType, ContextType, Partial<GQLArticleTransformedContentArgs>>;
   updated?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  visualElement?: Resolver<Maybe<GQLResolversTypes['VisualElement']>, ParentType, ContextType>;
-  visualElementEmbed?: Resolver<Maybe<GQLResolversTypes['ResourceEmbed']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -3785,7 +3792,7 @@ export type GQLRelatedContentResolvers<ContextType = any, ParentType extends GQL
 };
 
 export type GQLResourceResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Resource'] = GQLResolversParentTypes['Resource']> = {
-  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType, Partial<GQLResourceArticleArgs>>;
+  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType>;
   availability?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   breadcrumbs?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   contentUri?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -3796,6 +3803,7 @@ export type GQLResourceResolvers<ContextType = any, ParentType extends GQLResolv
   meta?: Resolver<Maybe<GQLResolversTypes['Meta']>, ParentType, ContextType>;
   metadata?: Resolver<GQLResolversTypes['TaxonomyMetadata'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parents?: Resolver<Maybe<Array<GQLResolversTypes['Topic']>>, ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   paths?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -4051,7 +4059,7 @@ export type GQLTitleResolvers<ContextType = any, ParentType extends GQLResolvers
 
 export type GQLTopicResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Topic'] = GQLResolversParentTypes['Topic']> = {
   alternateTopics?: Resolver<Maybe<Array<GQLResolversTypes['Topic']>>, ParentType, ContextType>;
-  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType, Partial<GQLTopicArticleArgs>>;
+  article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType>;
   availability?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   breadcrumbs?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   contentUri?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -4063,6 +4071,7 @@ export type GQLTopicResolvers<ContextType = any, ParentType extends GQLResolvers
   meta?: Resolver<Maybe<GQLResolversTypes['Meta']>, ParentType, ContextType>;
   metadata?: Resolver<GQLResolversTypes['TaxonomyMetadata'], ParentType, ContextType>;
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  oembed?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parent?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   parentId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -4080,6 +4089,14 @@ export type GQLTopicResolvers<ContextType = any, ParentType extends GQLResolvers
 export type GQLTranscriptionResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Transcription'] = GQLResolversParentTypes['Transcription']> = {
   pinyin?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   traditional?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type GQLTransformedArticleContentResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['TransformedArticleContent'] = GQLResolversParentTypes['TransformedArticleContent']> = {
+  content?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaData?: Resolver<Maybe<GQLResolversTypes['ArticleMetaData']>, ParentType, ContextType>;
+  visualElement?: Resolver<Maybe<GQLResolversTypes['VisualElement']>, ParentType, ContextType>;
+  visualElementEmbed?: Resolver<Maybe<GQLResolversTypes['ResourceEmbed']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -4282,6 +4299,7 @@ export type GQLResolvers<ContextType = any> = {
   Title?: GQLTitleResolvers<ContextType>;
   Topic?: GQLTopicResolvers<ContextType>;
   Transcription?: GQLTranscriptionResolvers<ContextType>;
+  TransformedArticleContent?: GQLTransformedArticleContentResolvers<ContextType>;
   UpdatedFolder?: GQLUpdatedFolderResolvers<ContextType>;
   UpdatedFolderResource?: GQLUpdatedFolderResourceResolvers<ContextType>;
   UptimeAlert?: GQLUptimeAlertResolvers<ContextType>;


### PR DESCRIPTION
Avhengig av https://github.com/NDLANO/ndla-frontend/pull/1793

Dette gjøres primært ved å kun hente `relatedContent` og `transformedContent` når en faktisk ber om det. Dette vil stort sett merkes i henting av masthead, men mistenker at det er et par andre steder vi kan slippe unna med å ikke hente ut innhold. Personlig mener jeg også at dette blir en mye "ryddigere" måte å sette opp article-resolveren på. Nå returnerer vi bare en fullverdig artikkel, mens forskjellene mellom graphql og den faktiske artikkel-typen spesifiseres i article-resolveren.

`oembed` er flyttet fra `article`-skjemaet til topic og resource. Såvidt jeg vet henter vi ikke `oembed`-data for kontekstløse artikler, så denne endringen vil kun føre til at vi må flytte der feltet hentes i frontend.

Grundigere testing kreves. Ser ut som at ED funker helt fint uten endringer.