### PR TITLE
Return link to ndla-frontend and not listing-frontend

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -60,27 +60,10 @@ export const h5pHostUrl = () => {
   }
 };
 
-const listingFrontendDomain = () => {
-  const listingDomain = process.env.LISTING_DOMAIN;
-  if (!listingDomain) {
-    switch (process.env.NDLA_ENVIRONMENT) {
-      case "local":
-        return "http://localhost:30020";
-      case "prod":
-        return "https://liste.ndla.no";
-      default:
-        return `https://liste.${process.env.NDLA_ENVIRONMENT ?? "test"}.ndla.no`;
-    }
-  } else {
-    return listingDomain;
-  }
-};
-
 export const port = getEnvironmentVariabel("PORT", "4000");
 export const apiUrl = getEnvironmentVariabel("API_URL", ndlaApiUrl());
 export const localConverter = getEnvironmentVariabel("LOCAL_CONVERTER", false);
 export const ndlaUrl = getEnvironmentVariabel("NDLA_URL", ndlaFrontendUrl());
-export const listingUrl = getEnvironmentVariabel("NDLA_LISTING_URL", listingFrontendDomain());
 export const uptimeOwner = getEnvironmentVariabel("UPTIME_OWNER", "NDLANO");
 export const uptimeRepo = getEnvironmentVariabel("UPTIME_REPO", "oppetid");
 export const uptimeToken = getEnvironmentVariabel("UPTIME_API_TOKEN", undefined);

--- a/src/utils/toArticleMetaData.ts
+++ b/src/utils/toArticleMetaData.ts
@@ -134,7 +134,7 @@ const conceptMetaData = (
     id: concept.id.toString(),
     title: concept.title.title,
     copyright: concept.copyright,
-    src: `${ndlaUrl}/concept/${concept.id}`,
+    src: `${ndlaUrl}/embed-iframe/concept/${concept.id}`,
     content: concept.content?.htmlContent ?? "",
     metaImageUrl: concept.metaImage?.url,
   };

--- a/src/utils/toArticleMetaData.ts
+++ b/src/utils/toArticleMetaData.ts
@@ -11,7 +11,7 @@ import { IConcept, IConceptSummary } from "@ndla/types-backend/concept-api";
 import { IImageMetaInformationV3 } from "@ndla/types-backend/image-api";
 import { ConceptVisualElementMeta, EmbedMetaData } from "@ndla/types-embed";
 import { licenseFixer, roleMapper } from "./apiHelpers";
-import { listingUrl } from "../config";
+import { ndlaUrl } from "../config";
 import {
   GQLArticleMetaData,
   GQLAudioLicense,
@@ -134,8 +134,8 @@ const conceptMetaData = (
     id: concept.id.toString(),
     title: concept.title.title,
     copyright: concept.copyright,
-    src: `${listingUrl}/concepts/${concept.id}`,
-    content: concept.content?.content ?? "",
+    src: `${ndlaUrl}/concept/${concept.id}`,
+    content: concept.content?.htmlContent ?? "",
     metaImageUrl: concept.metaImage?.url,
   };
   if (concept.conceptType === "gloss") {


### PR DESCRIPTION
Første steg i å fase ut listing-frontend. Trur egentlig ikkje feltet brukes i ndla-frontend, men i det minste returnerer vi en url vi kan bruke.