### PR TITLE
Do not auto-convert strings to numbers when transforming embed data

### DIFF
--- a/src/utils/getEmbedsFromContent.ts
+++ b/src/utils/getEmbedsFromContent.ts
@@ -19,6 +19,12 @@ export const getEmbedsFromContent = (html: CheerioAPI): CheerioEmbed[] => {
     .toArray()
     .map((embed) => ({
       embed: html(embed),
-      data: html(embed).data() as EmbedData,
+      // Cheerio automatically converts number-like strings to numbers, which in turn can break html-react-parser.
+      // Seeing as article-converter expects to only receive strings for embed data, we need to convert all numbers to strings (again).
+      data: Object.entries(html(embed).data()).reduce((acc, [key, value]) => {
+        //@ts-ignore
+        acc[key] = typeof value === "number" ? `${value}` : value;
+        return acc;
+      }, {}) as EmbedData,
     }));
 };


### PR DESCRIPTION
Vil tro det har vært sånn her i en evighet. Egentlig litt overrasket over at vi ikke har truffet det før.