### PR TITLE
Add coverphoto resolver to learningpath

### DIFF
--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -6,9 +6,10 @@
  *
  */
 
-import { fetchLearningpath, fetchNode, fetchOembed } from "../api";
+import { fetchImageV3, fetchLearningpath, fetchNode, fetchOembed } from "../api";
 import {
   GQLLearningpath,
+  GQLLearningpathCoverphoto,
   GQLLearningpathStep,
   GQLLearningpathStepOembed,
   GQLQueryLearningpathArgs,
@@ -38,6 +39,21 @@ const buildOembedFromIframeUrl = (url: string): GQLLearningpathStepOembed => {
 };
 
 export const resolvers = {
+  Learningpath: {
+    async coverphoto(
+      learningpath: GQLLearningpath,
+      _: any,
+      context: ContextWithLoaders,
+    ): Promise<GQLLearningpathCoverphoto | undefined> {
+      if (!learningpath.coverphoto) return undefined;
+      const imageId = learningpath.coverphoto?.metaUrl.split("/").pop() ?? "";
+      const image = await fetchImageV3(imageId, context);
+      return {
+        ...learningpath.coverphoto,
+        url: image.image.imageUrl,
+      };
+    },
+  },
   LearningpathStep: {
     async oembed(
       learningpathStep: GQLLearningpathStep,


### PR DESCRIPTION
Gjør dette på samme måte som for artikler.
Skulle egentlig ønske vi slapp å gjøre dette kallet, men dersom vi trenger fileendelse i metadataen så ser jeg ikke helt hvordan vi skal komme rundt det uten å øke kompleksiteten betraktelig. 

Tror dette er lesser-evil 😄 

Backend pr her: https://github.com/NDLANO/backend/pull/443