### PR TITLE
Stop including path label for prometheus metrics

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -39,7 +39,7 @@ const app = express();
 
 const metricsMiddleware = promBundle({
   includeMethod: true,
-  includePath: true,
+  includePath: false,
   excludeRoutes: ["/health"],
 });
 


### PR DESCRIPTION
Siden labelen ikke blir begrenset på antall paths vi har, men alle paths som finnes blir lablet så blir det litt tungt for prometheus.

Ref: https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels