### PR TITLE
Require one of the "main" params when fetching `/taxonomy/v1/nodes`

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -176,19 +176,21 @@ export async function fetchVersion(hash: string, context: Context): Promise<Vers
   return json?.[0];
 }
 
-interface NodeQueryParams {
-  contentURI?: string;
-  contextId?: string;
-  nodeType?: NodeType;
+interface NodeQueryParamsBase {
   language?: string;
   isRoot?: boolean;
   isContext?: boolean;
-  key?: string;
   value?: string;
   isVisible?: boolean;
   includeContexts?: boolean;
   filterProgrammes?: boolean;
 }
+
+type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<T, Exclude<keyof T, Keys>> &
+  { [K in Keys]-?: Required<Pick<T, K>> & Partial<Record<Exclude<Keys, K>, undefined>> }[Keys];
+
+type NodeQueryParams = NodeQueryParamsBase &
+  RequireAtLeastOne<{ contextId?: string; contentURI?: string; key?: string; nodeType?: NodeType }>;
 
 export const queryNodes = async (params: NodeQueryParams, context: Context): Promise<Node[]> => {
   const res = await fetch(`/${context.taxonomyUrl}/v1/nodes?${qs.stringify(params)}`, context);

--- a/src/resolvers/programmeResolvers.ts
+++ b/src/resolvers/programmeResolvers.ts
@@ -50,9 +50,15 @@ export const Query = {
     context: ContextWithLoaders,
   ): Promise<GQLProgrammePage> {
     if (path && !path.includes("__")) {
-      throw Error("Tried to fetch programme with invalid path");
+      throw new Error("Tried to fetch programme with invalid path");
     }
+
     const id = path?.split("__")[1] || contextId;
+
+    if (!id) {
+      throw new Error(`Failed to find a programme with contextId ${contextId}`);
+    }
+
     const node = await queryNodes({ contextId: id, language: context.language }, context);
     if (!node[0]) {
       throw new Error(`Failed to find a programme with contextId ${contextId}`);

--- a/src/resolvers/topicResolvers.ts
+++ b/src/resolvers/topicResolvers.ts
@@ -117,7 +117,7 @@ export const resolvers = {
     },
     async alternateTopics(topic: Node, _: any, context: ContextWithLoaders): Promise<GQLTopic[] | undefined> {
       const { contentUri, id, path } = topic;
-      if (!path) {
+      if (!path && contentUri) {
         const nodes = await queryNodes(
           {
             contentURI: contentUri,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1414,7 +1414,7 @@ export const typeDefs = gql`
     programme(path: String, contextId: String): ProgrammePage
     subjects(metadataFilterKey: String, metadataFilterValue: String, filterVisible: Boolean, ids: [String!]): [Subject!]
     topic(id: String!, subjectId: String): Topic
-    topics(contentUri: String, filterVisible: Boolean): [Topic!]
+    topics(contentUri: String!, filterVisible: Boolean): [Topic!]
     frontpage: FrontpageMenu
     competenceGoals(codes: [String], language: String): [CompetenceGoal!]
     competenceGoal(code: String!, language: String): CompetenceGoal

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1869,7 +1869,7 @@ export type GQLQueryTopicArgs = {
 
 
 export type GQLQueryTopicsArgs = {
-  contentUri?: InputMaybe<Scalars['String']>;
+  contentUri: Scalars['String'];
   filterVisible?: InputMaybe<Scalars['Boolean']>;
 };
 
@@ -3927,7 +3927,7 @@ export type GQLQueryResolvers<ContextType = any, ParentType extends GQLResolvers
   subjectpage?: Resolver<Maybe<GQLResolversTypes['SubjectPage']>, ParentType, ContextType, RequireFields<GQLQuerySubjectpageArgs, 'id'>>;
   subjects?: Resolver<Maybe<Array<GQLResolversTypes['Subject']>>, ParentType, ContextType, Partial<GQLQuerySubjectsArgs>>;
   topic?: Resolver<Maybe<GQLResolversTypes['Topic']>, ParentType, ContextType, RequireFields<GQLQueryTopicArgs, 'id'>>;
-  topics?: Resolver<Maybe<Array<GQLResolversTypes['Topic']>>, ParentType, ContextType, Partial<GQLQueryTopicsArgs>>;
+  topics?: Resolver<Maybe<Array<GQLResolversTypes['Topic']>>, ParentType, ContextType, RequireFields<GQLQueryTopicsArgs, 'contentUri'>>;
 };
 
 export type GQLReferenceResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Reference'] = GQLResolversParentTypes['Reference']> = {


### PR DESCRIPTION
Å kalle `/taxonomy/v1/nodes` uten queryparametere er riiimelig dyrt så typer det slik at det er påkrevd å sende med, og fikser det de stedene det brukes :smile: 