### PR TITLE
Add support for fetching nodebb user by id & allow missing user on post

### DIFF
--- a/src/api/arenaApi.ts
+++ b/src/api/arenaApi.ts
@@ -29,6 +29,7 @@ import {
   GQLQueryArenaTopicArgs,
   GQLQueryArenaTopicsByUserArgs,
   GQLQueryArenaUserArgs,
+  GQLQueryArenaUserByIdArgs,
 } from "../types/schema";
 import { fetch, resolveJson } from "../utils/apiHelpers";
 
@@ -182,6 +183,20 @@ export const fetchArenaUser = async ({ username }: GQLQueryArenaUserArgs, contex
   const csrfHeaders = await fetchCsrfTokenForSession(context);
   const response = await fetch(
     `/groups/api/user/username/${username}`,
+    { ...context, shouldUseCache: false },
+    { headers: csrfHeaders },
+  );
+  const resolved: any = await resolveJson(response);
+  return toArenaUser(resolved);
+};
+
+export const fetchArenaUserById = async (
+  { id }: GQLQueryArenaUserByIdArgs,
+  context: Context,
+): Promise<GQLArenaUser> => {
+  const csrfHeaders = await fetchCsrfTokenForSession(context);
+  const response = await fetch(
+    `/groups/api/user/uid/${id}`,
     { ...context, shouldUseCache: false },
     { headers: csrfHeaders },
   );

--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -435,8 +435,9 @@ export const resolvers = {
     },
   },
   ArenaPost: {
-    async user(post: GQLArenaPost, _: any, context: ContextWithLoaders): Promise<GQLArenaUser> {
-      return fetchArenaUserById({ id: post.user.id }, context);
+    async user(post: GQLArenaPost, _: any, context: ContextWithLoaders): Promise<GQLArenaUser | undefined> {
+      if (!post?.user?.id) return undefined;
+      return fetchArenaUserById({ id: post?.user?.id }, context);
     },
   },
 };

--- a/src/resolvers/arenaResolvers.ts
+++ b/src/resolvers/arenaResolvers.ts
@@ -17,6 +17,7 @@ import {
   fetchArenaTopic,
   fetchArenaTopicsByUser,
   fetchArenaUser,
+  fetchArenaUserById,
   markNotificationRead,
   newFlag,
   newTopic,
@@ -84,6 +85,7 @@ import {
   GQLMyNdlaPersonalData,
   GQLMutationDeleteCategoryArgs,
   GQLMutationSortArenaCategoriesArgs,
+  GQLQueryArenaUserByIdArgs,
 } from "../types/schema";
 
 import parseMarkdown from "../utils/parseMarkdown";
@@ -103,6 +105,7 @@ export const Query: Pick<
   | "arenaTopicsByUserV2"
   | "arenaNotificationsV2"
   | "arenaUserV2"
+  | "arenaUserById"
   | "arenaRecentTopicsV2"
   | "arenaAllFlags"
   | "arenaPostInContext"
@@ -110,6 +113,9 @@ export const Query: Pick<
 > = {
   async arenaUser(_: any, params: GQLQueryArenaUserArgs, context: ContextWithLoaders): Promise<GQLArenaUser> {
     return fetchArenaUser(params, context);
+  },
+  async arenaUserById(_: any, params: GQLQueryArenaUserByIdArgs, context: ContextWithLoaders): Promise<GQLArenaUser> {
+    return fetchArenaUserById(params, context);
   },
   async arenaUserV2(_: any, params: GQLQueryArenaUserV2Args, context: ContextWithLoaders): Promise<GQLArenaUserV2> {
     return await myndla.fetchArenaUser(params.username, context);
@@ -430,7 +436,7 @@ export const resolvers = {
   },
   ArenaPost: {
     async user(post: GQLArenaPost, _: any, context: ContextWithLoaders): Promise<GQLArenaUser> {
-      return fetchArenaUser({ username: post.user.username }, context);
+      return fetchArenaUserById({ id: post.user.id }, context);
     },
   },
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1503,6 +1503,7 @@ export const typeDefs = gql`
     arenaCategories: [ArenaCategory!]!
     arenaCategory(categoryId: Int!, page: Int!): ArenaCategory
     arenaUser(username: String!): ArenaUser
+    arenaUserById(id: Int!): ArenaUser
     arenaAllFlags(page: Int, pageSize: Int): PaginatedPosts!
     arenaTopic(topicId: Int!, page: Int): ArenaTopic
     arenaRecentTopics: [ArenaTopic!]!

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1215,7 +1215,7 @@ export const typeDefs = gql`
     content: String!
     timestamp: String!
     isMainPost: Boolean!
-    user: ArenaUser!
+    user: ArenaUser
     deleted: Boolean!
     flagId: Int
     toPid: Int

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -126,7 +126,7 @@ export type GQLArenaPost = {
   topicId: Scalars['Int'];
   upvoted: Scalars['Boolean'];
   upvotes: Scalars['Int'];
-  user: GQLArenaUser;
+  user?: Maybe<GQLArenaUser>;
 };
 
 export type GQLArenaPostV2 = {
@@ -2817,7 +2817,7 @@ export type GQLArenaPostResolvers<ContextType = any, ParentType extends GQLResol
   topicId?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   upvoted?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
   upvotes?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
-  user?: Resolver<GQLResolversTypes['ArenaUser'], ParentType, ContextType>;
+  user?: Resolver<Maybe<GQLResolversTypes['ArenaUser']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1505,6 +1505,7 @@ export type GQLQuery = {
   arenaTopicsByUser: Array<GQLArenaTopic>;
   arenaTopicsByUserV2: GQLPaginatedTopics;
   arenaUser?: Maybe<GQLArenaUser>;
+  arenaUserById?: Maybe<GQLArenaUser>;
   arenaUserV2?: Maybe<GQLArenaUserV2>;
   article?: Maybe<GQLArticle>;
   articleResource?: Maybe<GQLResource>;
@@ -1623,6 +1624,11 @@ export type GQLQueryArenaTopicsByUserV2Args = {
 
 export type GQLQueryArenaUserArgs = {
   username: Scalars['String'];
+};
+
+
+export type GQLQueryArenaUserByIdArgs = {
+  id: Scalars['Int'];
 };
 
 
@@ -3887,6 +3893,7 @@ export type GQLQueryResolvers<ContextType = any, ParentType extends GQLResolvers
   arenaTopicsByUser?: Resolver<Array<GQLResolversTypes['ArenaTopic']>, ParentType, ContextType, RequireFields<GQLQueryArenaTopicsByUserArgs, 'userSlug'>>;
   arenaTopicsByUserV2?: Resolver<GQLResolversTypes['PaginatedTopics'], ParentType, ContextType, RequireFields<GQLQueryArenaTopicsByUserV2Args, 'userId'>>;
   arenaUser?: Resolver<Maybe<GQLResolversTypes['ArenaUser']>, ParentType, ContextType, RequireFields<GQLQueryArenaUserArgs, 'username'>>;
+  arenaUserById?: Resolver<Maybe<GQLResolversTypes['ArenaUser']>, ParentType, ContextType, RequireFields<GQLQueryArenaUserByIdArgs, 'id'>>;
   arenaUserV2?: Resolver<Maybe<GQLResolversTypes['ArenaUserV2']>, ParentType, ContextType, RequireFields<GQLQueryArenaUserV2Args, 'username'>>;
   article?: Resolver<Maybe<GQLResolversTypes['Article']>, ParentType, ContextType, RequireFields<GQLQueryArticleArgs, 'id'>>;
   articleResource?: Resolver<Maybe<GQLResolversTypes['Resource']>, ParentType, ContextType, Partial<GQLQueryArticleResourceArgs>>;


### PR DESCRIPTION
Trengs dersom en bruker er slettet men posten finnes fremdeles.
Kræsjet i prod før jeg lagde [denne hacken](https://github.com/NDLANO/graphql-api/pull/478), men jeg tror denne løsningen blir bedre.