### PR TITLE
Change loglevel for specific status codes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ import {
 import { resolvers } from "./resolvers";
 import { typeDefs } from "./schema";
 import correlationIdMiddleware from "./utils/correlationIdMiddleware";
-import getLogger from "./utils/logger";
+import { logError } from "./utils/logger";
 import loggerMiddleware from "./utils/loggerMiddleware";
 
 const GRAPHQL_PORT = port;
@@ -129,6 +129,7 @@ async function getContext({ req, res }: { req: Request; res: Response }): Promis
 app.get("/health", (req: Request, res: Response) => {
   res.status(200).json({ status: 200, text: "Health check ok" });
 });
+
 async function startApolloServer() {
   const server = new ApolloServer({
     typeDefs,
@@ -136,8 +137,8 @@ async function startApolloServer() {
     introspection: true,
     allowBatchedHttpRequests: true,
     includeStacktraceInErrorResponses: true,
-    formatError(err: any) {
-      getLogger().error(err);
+    formatError(err) {
+      logError(err);
       // Remove stack traces from client response
       const extensions = err?.extensions ? { ...err?.extensions, stacktrace: undefined } : err?.extensions;
       return {


### PR DESCRIPTION
Gjør som i ndla-frontend og logger 401,403,404 og 410 som `info` istedetfor `error`.
