### PR TITLE
Dont parse markdown for manuscript

### DIFF
--- a/src/api/embedsApi.ts
+++ b/src/api/embedsApi.ts
@@ -91,11 +91,6 @@ const audioMeta: Fetch<AudioMetaData> = async ({ embedData, context }) => {
   const audio = await fetchAudioV2(context, embedData.resourceId);
   const coverPhotoId = audio.podcastMeta?.coverPhoto?.id;
   let imageMeta: IImageMetaInformationV3 | undefined;
-  if (audio.manuscript) {
-    audio.manuscript.manuscript = parseMarkdown({
-      markdown: audio.manuscript.manuscript,
-    });
-  }
   if (coverPhotoId) {
     imageMeta = await fetchImageWrapper(coverPhotoId, context);
   }

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -32,7 +32,6 @@ import {
   GQLRelatedContent,
   GQLVisualElementOembed,
 } from "../types/schema";
-import parseMarkdown from "../utils/parseMarkdown";
 
 export const Query = {
   async article(_: any, { id }: GQLQueryArticleArgs, context: ContextWithLoaders): Promise<IArticleV2> {
@@ -103,10 +102,7 @@ export const resolvers = {
       };
     },
     introduction(article: IArticleV2): string {
-      return parseMarkdown({
-        markdown: article.introduction?.htmlIntroduction ?? "",
-        inline: true,
-      });
+      return article.introduction?.introduction ?? "";
     },
     htmlIntroduction(article: IArticleV2): string {
       return article.introduction?.htmlIntroduction ?? "";


### PR DESCRIPTION
Manuscript er lagra i html-format og article-converter dytter dette rått inn med dangerouslySetInnerHTML.