### PR TITLE
Add contextid to programme

### DIFF
--- a/src/resolvers/programmeResolvers.ts
+++ b/src/resolvers/programmeResolvers.ts
@@ -20,7 +20,7 @@ import { nodeToTaxonomyEntity } from "../utils/apiHelpers";
 
 const nodeToProgramme = (node: Node, language: string): GQLProgrammePage => {
   return {
-    id: node.id,
+    id: node.contextId ?? node.id,
     title: {
       title: node.name,
       language: language,

--- a/src/resolvers/programmeResolvers.ts
+++ b/src/resolvers/programmeResolvers.ts
@@ -20,7 +20,8 @@ import { nodeToTaxonomyEntity } from "../utils/apiHelpers";
 
 const nodeToProgramme = (node: Node, language: string): GQLProgrammePage => {
   return {
-    id: node.contextId ?? node.id,
+    id: node.id,
+    contextId: node.contextId,
     title: {
       title: node.name,
       language: language,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -783,6 +783,7 @@ export const typeDefs = gql`
 
   type ProgrammePage {
     id: String!
+    contextId: String
     title: Title!
     url: String
     contentUri: String

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1532,6 +1532,7 @@ export type GQLPodcastSeriesWithEpisodes = GQLPodcastSeriesBase & {
 export type GQLProgrammePage = {
   __typename?: 'ProgrammePage';
   contentUri?: Maybe<Scalars['String']>;
+  contextId?: Maybe<Scalars['String']>;
   desktopImage?: Maybe<GQLMetaImage>;
   grades?: Maybe<Array<GQLGrade>>;
   id: Scalars['String'];
@@ -4024,6 +4025,7 @@ export type GQLPodcastSeriesWithEpisodesResolvers<ContextType = any, ParentType 
 
 export type GQLProgrammePageResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['ProgrammePage'] = GQLResolversParentTypes['ProgrammePage']> = {
   contentUri?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
+  contextId?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   desktopImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   grades?: Resolver<Maybe<Array<GQLResolversTypes['Grade']>>, ParentType, ContextType>;
   id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;


### PR DESCRIPTION
Dette gjøres for å kunne matche url mot contextID uten å måtte ta hensyn til språket som er valgt. Det vil gjøre koden som setter current på programfagmeny litt enklere.