### PR TITLE
Link to article-url if context fetched is invisible.

### DIFF
--- a/src/api/embedsApi.ts
+++ b/src/api/embedsApi.ts
@@ -189,11 +189,14 @@ const contentLinkMeta: Fetch<ContentLinkMetaData> = async ({ embedData, context,
   let path = `${host}/${context.language}/${contentType}/${embedData.contentId}`;
   let url = `${host}/${context.language}/${contentType}/${embedData.contentId}`;
   const nodes = await queryNodes(
-    { contentURI, language: context.language, includeContexts: true, filterProgrammes: true },
+    { contentURI, language: context.language, includeContexts: true, filterProgrammes: true, isVisible: true },
     context,
   );
   const node = nodes.find((n) => !!n.path);
-  const ctx = opts.subject ? node?.contexts?.find((c) => c.rootId === opts.subject) : node?.contexts?.[0];
+  const ctx = opts.subject ? node?.contexts?.find((c) => c.rootId === opts.subject) : node?.context;
+  if (!ctx?.isVisible) {
+    return { path };
+  }
   const nodePath = ctx?.path ?? node?.path;
   const nodeUrl = ctx?.url ?? node?.url;
 


### PR DESCRIPTION
Problemet kan sees på https://ndla.no/subject:d2f5a058-a8fe-4e9b-861d-959a47627b07/topic:15fe7f67-24ec-41e3-96a7-d7c4501f43d0/topic:b0f773a5-0d14-4d60-be4a-6d2c82826fb2/resource:d61dec49-7fec-4470-8d18-c4043767892b

Første lenka i artikkelen peiker på en publisert artikkel, men en som kun finnes i en skjult kontekst. Denne lar seg ikkje åpne og derfor blir du stående på en side som refererer til en anna plassering som er den samme, og du får ikkje vist artikkelen. Denne endringa gjør at dersom kontekst som hentes fra tax er usynlig så vises publisert artikkel uten kontekst.