### PR TITLE
Return first if language not present

### DIFF
--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -196,23 +196,24 @@ export const nodeToTaxonomyEntity = (node: Node, context: ContextWithLoaders): G
 };
 
 const toGQLTaxonomyContext = (ctx: TaxonomyContext, name: string, context: ContextWithLoaders): GQLTaxonomyContext => {
-  const breadcrumbs = ctx.breadcrumbs[context.language] || ctx.breadcrumbs[defaultLanguage] || [];
-  const relevance = ctx.relevance[context.language] || ctx.relevance[defaultLanguage] || "";
+  const breadcrumbs = ctx.breadcrumbs[context.language] || ctx.breadcrumbs[defaultLanguage] || ctx.breadcrumbs[0];
+  const relevance = ctx.relevance[context.language] || ctx.relevance[defaultLanguage] || ctx.relevance[0];
   const url = ctx.url || ctx.path;
   const parents = ctx.parents.map((parent) => toGQLTaxonomyCrumb(parent, context));
   return {
     ...ctx,
     url,
     name,
-    breadcrumbs,
-    relevance,
+    breadcrumbs: breadcrumbs ?? [],
+    relevance: relevance ?? "",
     parents,
   };
 };
 
 const toGQLTaxonomyCrumb = (crumb: TaxonomyCrumb, context: ContextWithLoaders): GQLTaxonomyCrumb => {
+  const name = crumb.name[context.language] || crumb.name[defaultLanguage] || crumb.name[0];
   return {
     ...crumb,
-    name: crumb.name[context.language] || crumb.name[defaultLanguage] || "",
+    name: name ?? "",
   };
 };


### PR DESCRIPTION
La merke til at https://ndla.no/subject:1:a5d7da3a-8a19-4a83-9b3f-3c855621df70/topic:1:11f13e74-7cb8-4651-8d10-0927e7a9de48/topic:1:abc4aa51-8cc3-47a3-902b-f3e10a453fac har en tom streng i brødsmulestien. Det er fordi vi har begynt å bruke node-endepunkt og leddet kun har språkvariant sma og blir dermed ikkje vist med gammel kode.

Dette fikser slik at første ledd vises dersom valgt språk ikkje treffer.