### PR TITLE
Return url for cross-subject topics

### DIFF
--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -67,6 +67,9 @@ export const resolvers = {
       context: ContextWithLoaders,
     ): Promise<GQLCrossSubjectElement[]> {
       const crossSubjectCodes = article.grepCodes?.filter((code) => code.startsWith("TT")) ?? [];
+      if (!crossSubjectCodes.length) {
+        return [];
+      }
       const language =
         article.supportedLanguages?.find((lang) => lang === context.language) ??
         article.supportedLanguages?.[0] ??

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -77,7 +77,7 @@ export const resolvers = {
       const crossSubjectTopicInfo = await fetchCrossSubjectTopicsByCode(crossSubjectCodes, language, context);
       const topics = await fetchSubjectTopics(args.subjectId, context);
       return crossSubjectTopicInfo.map((crossSubjectTopic) => {
-        const topic = topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title);
+        const topic = topics.find((topic) => topic.name === crossSubjectTopic.title);
         return {
           title: crossSubjectTopic.title,
           code: crossSubjectTopic.code,

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -73,12 +73,16 @@ export const resolvers = {
         context.language;
       const crossSubjectTopicInfo = await fetchCrossSubjectTopicsByCode(crossSubjectCodes, language, context);
       const topics = await fetchSubjectTopics(args.subjectId, context);
-      return crossSubjectTopicInfo.map((crossSubjectTopic) => ({
-        title: crossSubjectTopic.title,
-        code: crossSubjectTopic.code,
-        id: crossSubjectTopic.id,
-        path: topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title)?.path,
-      }));
+      return crossSubjectTopicInfo.map((crossSubjectTopic) => {
+        const topic = topics.find((topic: { name: string }) => topic.name === crossSubjectTopic.title);
+        return {
+          title: crossSubjectTopic.title,
+          code: crossSubjectTopic.code,
+          id: crossSubjectTopic.id,
+          path: topic?.path,
+          url: topic?.url,
+        };
+      });
     },
     async concepts(article: IArticleV2, _: any, context: ContextWithLoaders): Promise<IConceptSummary[]> {
       if (article?.conceptIds && article.conceptIds.length > 0) {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -658,6 +658,7 @@ export const typeDefs = gql`
     title: String!
     code: String
     path: String
+    url: String
   }
 
   type Element {

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -569,6 +569,7 @@ export type GQLCrossSubjectElement = {
   code?: Maybe<Scalars['String']>;
   path?: Maybe<Scalars['String']>;
   title: Scalars['String'];
+  url?: Maybe<Scalars['String']>;
 };
 
 export type GQLDescription = {
@@ -904,6 +905,7 @@ export type GQLLearningpathStep = {
   id: Scalars['Int'];
   license?: Maybe<GQLLicense>;
   metaUrl: Scalars['String'];
+  node?: Maybe<GQLNode>;
   oembed?: Maybe<GQLLearningpathStepOembed>;
   resource?: Maybe<GQLResource>;
   revision: Scalars['Int'];
@@ -913,6 +915,13 @@ export type GQLLearningpathStep = {
   supportedLanguages: Array<Scalars['String']>;
   title: Scalars['String'];
   type: Scalars['String'];
+};
+
+
+export type GQLLearningpathStepNodeArgs = {
+  parentContextId?: InputMaybe<Scalars['String']>;
+  parentId?: InputMaybe<Scalars['String']>;
+  rootId?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -3369,6 +3378,7 @@ export type GQLCrossSubjectElementResolvers<ContextType = any, ParentType extend
   code?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   path?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<Maybe<GQLResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -3699,6 +3709,7 @@ export type GQLLearningpathStepResolvers<ContextType = any, ParentType extends G
   id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
   license?: Resolver<Maybe<GQLResolversTypes['License']>, ParentType, ContextType>;
   metaUrl?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  node?: Resolver<Maybe<GQLResolversTypes['Node']>, ParentType, ContextType, Partial<GQLLearningpathStepNodeArgs>>;
   oembed?: Resolver<Maybe<GQLResolversTypes['LearningpathStepOembed']>, ParentType, ContextType>;
   resource?: Resolver<Maybe<GQLResolversTypes['Resource']>, ParentType, ContextType, Partial<GQLLearningpathStepResourceArgs>>;
   revision?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;


### PR DESCRIPTION
Lenker til tverrfaglige rot-emner vises ikkje med korte urler. Dette gjør at dei lar seg vise fram med lenker i det minste. Krever også endring i ndla-frontend.