### PR TITLE
Add license filter for images

### DIFF
--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -34,6 +34,7 @@ export async function fetchImageV3(imageId: number | string, context: Context): 
 export async function searchImages(params: GQLQueryImageSearchArgs, context: Context): Promise<ISearchResultV3DTO> {
   const queryStr = qs.stringify({
     "page-size": params.pageSize,
+    license: params.license,
     page: params.page,
     query: params.query,
   });

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1777,7 +1777,7 @@ export const typeDefs = gql`
     arenaPostInContext(postId: Int!, pageSize: Int): ArenaTopicV2
     listArenaUserV2(page: Int, pageSize: Int, query: String, filterTeachers: Boolean): PaginatedArenaUsers!
     subjectCollection(language: String!): [Subject!]
-    imageSearch(query: String, page: Int, pageSize: Int): ImageSearch!
+    imageSearch(query: String, page: Int, pageSize: Int, license: String): ImageSearch!
     imageV3(id: String!): ImageMetaInformationV3
     learningpathStepOembed(url: String!): LearningpathStepOembed!
     opengraph(url: String!): ExternalOpengraph

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -2052,6 +2052,7 @@ export type GQLQueryImageArgs = {
 
 
 export type GQLQueryImageSearchArgs = {
+  license?: InputMaybe<Scalars['String']['input']>;
   page?: InputMaybe<Scalars['Int']['input']>;
   pageSize?: InputMaybe<Scalars['Int']['input']>;
   query?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
NDLA ønsker at kun cc-by-sa skal kunne velges som metabilde for læringsstier.