### PR TITLE
feat: support node search type

### DIFF
--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { IMultiSearchSummaryDTO } from "@ndla/types-backend/search-api";
 import { Query as ArticleQuery, resolvers as articleResolvers } from "./articleResolvers";
 import { Query as ConceptQuery, resolvers as conceptResolvers } from "./conceptResolvers";
 import { Query as CurriculumQuery, resolvers as curriculumResolvers } from "./curriculumResolvers";
@@ -93,8 +94,10 @@ export const resolvers = {
   },
   SearchResult: {
     // Resolves SearchResult interface
-    __resolveType(searchResult: any) {
-      if (searchResult.learningResourceType === "learningpath") {
+    __resolveType(searchResult: IMultiSearchSummaryDTO) {
+      if (searchResult.resultType === "node") {
+        return "NodeSearchResult";
+      } else if (searchResult.learningResourceType === "learningpath") {
         return "LearningpathSearchResult";
       }
       return "ArticleSearchResult";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -933,20 +933,19 @@ export const typeDefs = gql`
   }
 
   interface SearchResult {
-    id: Int!
+    id: String!
     title: String!
-    htmlTitle: String!
     supportedLanguages: [String!]!
     url: String!
     metaDescription: String!
-    metaImage: MetaImage
-    traits: [String!]!
     context: SearchContext
     contexts: [SearchContext!]!
   }
 
+  union SearchResultUnion = ArticleSearchResult | LearningpathSearchResult | NodeSearchResult
+
   type ArticleSearchResult implements SearchResult {
-    id: Int!
+    id: String!
     title: String!
     htmlTitle: String!
     supportedLanguages: [String!]!
@@ -959,7 +958,7 @@ export const typeDefs = gql`
   }
 
   type LearningpathSearchResult implements SearchResult {
-    id: Int!
+    id: String!
     title: String!
     htmlTitle: String!
     supportedLanguages: [String!]!
@@ -967,6 +966,18 @@ export const typeDefs = gql`
     metaDescription: String!
     metaImage: MetaImage
     traits: [String!]!
+    context: SearchContext
+    contexts: [SearchContext!]!
+  }
+
+  type NodeSearchResult implements SearchResult {
+    id: String!
+    title: String!
+    htmlTitle: String!
+    supportedLanguages: [String!]!
+    url: String!
+    metaDescription: String!
+    metaImage: MetaImage
     context: SearchContext
     contexts: [SearchContext!]!
   }
@@ -981,11 +992,9 @@ export const typeDefs = gql`
     relevanceId: String!
     path: String!
     publicId: String!
-    parentIds: [String!]!
     language: String!
     isPrimary: Boolean!
     isActive: Boolean!
-    isVisible: Boolean!
     contextId: String!
     url: String!
   }

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -118,7 +118,7 @@ export type GQLArticleSearchResult = GQLSearchResult & {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
   htmlTitle: Scalars['String']['output'];
-  id: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
   metaDescription: Scalars['String']['output'];
   metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars['String']['output']>;
@@ -789,7 +789,7 @@ export type GQLLearningpathSearchResult = GQLSearchResult & {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
   htmlTitle: Scalars['String']['output'];
-  id: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
   metaDescription: Scalars['String']['output'];
   metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars['String']['output']>;
@@ -1252,6 +1252,19 @@ export type GQLNode = GQLTaxBase & GQLTaxonomyEntity & GQLWithArticle & {
 export type GQLNodeChildrenArgs = {
   nodeType?: InputMaybe<Scalars['String']['input']>;
   recursive?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type GQLNodeSearchResult = GQLSearchResult & {
+  __typename?: 'NodeSearchResult';
+  context?: Maybe<GQLSearchContext>;
+  contexts: Array<GQLSearchContext>;
+  htmlTitle: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  metaDescription: Scalars['String']['output'];
+  metaImage?: Maybe<GQLMetaImage>;
+  supportedLanguages: Array<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type GQLOwner = {
@@ -1759,9 +1772,7 @@ export type GQLSearchContext = {
   contextType: Scalars['String']['output'];
   isActive: Scalars['Boolean']['output'];
   isPrimary: Scalars['Boolean']['output'];
-  isVisible: Scalars['Boolean']['output'];
   language: Scalars['String']['output'];
-  parentIds: Array<Scalars['String']['output']>;
   path: Scalars['String']['output'];
   publicId: Scalars['String']['output'];
   relevance: Scalars['String']['output'];
@@ -1782,15 +1793,14 @@ export type GQLSearchContextResourceTypes = {
 export type GQLSearchResult = {
   context?: Maybe<GQLSearchContext>;
   contexts: Array<GQLSearchContext>;
-  htmlTitle: Scalars['String']['output'];
-  id: Scalars['Int']['output'];
+  id: Scalars['String']['output'];
   metaDescription: Scalars['String']['output'];
-  metaImage?: Maybe<GQLMetaImage>;
   supportedLanguages: Array<Scalars['String']['output']>;
   title: Scalars['String']['output'];
-  traits: Array<Scalars['String']['output']>;
   url: Scalars['String']['output'];
 };
+
+export type GQLSearchResultUnion = GQLArticleSearchResult | GQLLearningpathSearchResult | GQLNodeSearchResult;
 
 export type GQLSearchSuggestion = {
   __typename?: 'SearchSuggestion';
@@ -2177,12 +2187,16 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
   info: GraphQLResolveInfo
 ) => TResult | Promise<TResult>;
 
+/** Mapping of union types */
+export type GQLResolversUnionTypes<_RefType extends Record<string, unknown>> = {
+  SearchResultUnion: ( GQLArticleSearchResult ) | ( GQLLearningpathSearchResult ) | ( GQLNodeSearchResult );
+};
 
 /** Mapping of interface types */
 export type GQLResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
   FolderResourceMeta: ( GQLArticleFolderResourceMeta ) | ( GQLAudioFolderResourceMeta ) | ( GQLConceptFolderResourceMeta ) | ( GQLImageFolderResourceMeta ) | ( GQLLearningpathFolderResourceMeta ) | ( GQLVideoFolderResourceMeta );
   PodcastSeriesBase: ( GQLPodcastSeries ) | ( GQLPodcastSeriesWithEpisodes );
-  SearchResult: ( GQLArticleSearchResult ) | ( GQLLearningpathSearchResult );
+  SearchResult: ( GQLArticleSearchResult ) | ( GQLLearningpathSearchResult ) | ( GQLNodeSearchResult );
   TaxBase: ( GQLNode ) | ( GQLResource ) | ( GQLSubject ) | ( GQLTaxonomyCrumb ) | ( GQLTopic );
   TaxonomyEntity: ( GQLNode ) | ( GQLResource ) | ( GQLSubject ) | ( GQLTopic );
   WithArticle: ( GQLNode ) | ( GQLResource ) | ( GQLTopic );
@@ -2293,6 +2307,7 @@ export type GQLResolversTypes = {
   NewFolder: ResolverTypeWrapper<GQLNewFolder>;
   NewFolderResource: ResolverTypeWrapper<GQLNewFolderResource>;
   Node: ResolverTypeWrapper<GQLNode>;
+  NodeSearchResult: ResolverTypeWrapper<GQLNodeSearchResult>;
   Owner: ResolverTypeWrapper<GQLOwner>;
   PodcastLicense: ResolverTypeWrapper<GQLPodcastLicense>;
   PodcastMeta: ResolverTypeWrapper<GQLPodcastMeta>;
@@ -2315,6 +2330,7 @@ export type GQLResolversTypes = {
   SearchContext: ResolverTypeWrapper<GQLSearchContext>;
   SearchContextResourceTypes: ResolverTypeWrapper<GQLSearchContextResourceTypes>;
   SearchResult: ResolverTypeWrapper<GQLResolversInterfaceTypes<GQLResolversTypes>['SearchResult']>;
+  SearchResultUnion: ResolverTypeWrapper<GQLResolversUnionTypes<GQLResolversTypes>['SearchResultUnion']>;
   SearchSuggestion: ResolverTypeWrapper<GQLSearchSuggestion>;
   SearchWithoutPagination: ResolverTypeWrapper<Omit<GQLSearchWithoutPagination, 'results'> & { results: Array<GQLResolversTypes['SearchResult']> }>;
   SharedFolder: ResolverTypeWrapper<GQLSharedFolder>;
@@ -2456,6 +2472,7 @@ export type GQLResolversParentTypes = {
   NewFolder: GQLNewFolder;
   NewFolderResource: GQLNewFolderResource;
   Node: GQLNode;
+  NodeSearchResult: GQLNodeSearchResult;
   Owner: GQLOwner;
   PodcastLicense: GQLPodcastLicense;
   PodcastMeta: GQLPodcastMeta;
@@ -2478,6 +2495,7 @@ export type GQLResolversParentTypes = {
   SearchContext: GQLSearchContext;
   SearchContextResourceTypes: GQLSearchContextResourceTypes;
   SearchResult: GQLResolversInterfaceTypes<GQLResolversParentTypes>['SearchResult'];
+  SearchResultUnion: GQLResolversUnionTypes<GQLResolversParentTypes>['SearchResultUnion'];
   SearchSuggestion: GQLSearchSuggestion;
   SearchWithoutPagination: Omit<GQLSearchWithoutPagination, 'results'> & { results: Array<GQLResolversParentTypes['SearchResult']> };
   SharedFolder: GQLSharedFolder;
@@ -2593,7 +2611,7 @@ export type GQLArticleSearchResultResolvers<ContextType = any, ParentType extend
   context?: Resolver<Maybe<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
   contexts?: Resolver<Array<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
   htmlTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -3223,7 +3241,7 @@ export type GQLLearningpathSearchResultResolvers<ContextType = any, ParentType e
   context?: Resolver<Maybe<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
   contexts?: Resolver<Array<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
   htmlTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
@@ -3483,6 +3501,19 @@ export type GQLNodeResolvers<ContextType = any, ParentType extends GQLResolversP
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type GQLNodeSearchResultResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['NodeSearchResult'] = GQLResolversParentTypes['NodeSearchResult']> = {
+  context?: Resolver<Maybe<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
+  contexts?: Resolver<Array<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
+  htmlTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
+  supportedLanguages?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
+  title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  url?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type GQLOwnerResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['Owner'] = GQLResolversParentTypes['Owner']> = {
   name?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -3711,9 +3742,7 @@ export type GQLSearchContextResolvers<ContextType = any, ParentType extends GQLR
   contextType?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   isActive?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
   isPrimary?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
-  isVisible?: Resolver<GQLResolversTypes['Boolean'], ParentType, ContextType>;
   language?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  parentIds?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   path?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   publicId?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   relevance?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
@@ -3733,17 +3762,18 @@ export type GQLSearchContextResourceTypesResolvers<ContextType = any, ParentType
 };
 
 export type GQLSearchResultResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['SearchResult'] = GQLResolversParentTypes['SearchResult']> = {
-  __resolveType: TypeResolveFn<'ArticleSearchResult' | 'LearningpathSearchResult', ParentType, ContextType>;
+  __resolveType: TypeResolveFn<'ArticleSearchResult' | 'LearningpathSearchResult' | 'NodeSearchResult', ParentType, ContextType>;
   context?: Resolver<Maybe<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
   contexts?: Resolver<Array<GQLResolversTypes['SearchContext']>, ParentType, ContextType>;
-  htmlTitle?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  id?: Resolver<GQLResolversTypes['Int'], ParentType, ContextType>;
+  id?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
   metaDescription?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  metaImage?: Resolver<Maybe<GQLResolversTypes['MetaImage']>, ParentType, ContextType>;
   supportedLanguages?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
-  traits?: Resolver<Array<GQLResolversTypes['String']>, ParentType, ContextType>;
   url?: Resolver<GQLResolversTypes['String'], ParentType, ContextType>;
+};
+
+export type GQLSearchResultUnionResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['SearchResultUnion'] = GQLResolversParentTypes['SearchResultUnion']> = {
+  __resolveType: TypeResolveFn<'ArticleSearchResult' | 'LearningpathSearchResult' | 'NodeSearchResult', ParentType, ContextType>;
 };
 
 export type GQLSearchSuggestionResolvers<ContextType = any, ParentType extends GQLResolversParentTypes['SearchSuggestion'] = GQLResolversParentTypes['SearchSuggestion']> = {
@@ -4136,6 +4166,7 @@ export type GQLResolvers<ContextType = any> = {
   NewFolder?: GQLNewFolderResolvers<ContextType>;
   NewFolderResource?: GQLNewFolderResourceResolvers<ContextType>;
   Node?: GQLNodeResolvers<ContextType>;
+  NodeSearchResult?: GQLNodeSearchResultResolvers<ContextType>;
   Owner?: GQLOwnerResolvers<ContextType>;
   PodcastLicense?: GQLPodcastLicenseResolvers<ContextType>;
   PodcastMeta?: GQLPodcastMetaResolvers<ContextType>;
@@ -4157,6 +4188,7 @@ export type GQLResolvers<ContextType = any> = {
   SearchContext?: GQLSearchContextResolvers<ContextType>;
   SearchContextResourceTypes?: GQLSearchContextResourceTypesResolvers<ContextType>;
   SearchResult?: GQLSearchResultResolvers<ContextType>;
+  SearchResultUnion?: GQLSearchResultUnionResolvers<ContextType>;
   SearchSuggestion?: GQLSearchSuggestionResolvers<ContextType>;
   SearchWithoutPagination?: GQLSearchWithoutPaginationResolvers<ContextType>;
   SharedFolder?: GQLSharedFolderResolvers<ContextType>;


### PR DESCRIPTION
Del 1 av å støtte nodesøk. Har ikke lagt til muligheten for å hente ennå, dette gjør det kun mulig å differensiere mellom de forskjellige returtypene søke-API'et kan gi.