### PR TITLE
fix: derive subjectId from contextId if present in request

### DIFF
--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -21,16 +21,23 @@ interface ArticleParams {
 export const fetchTransformedContent = async (
   article: IArticleV2DTO,
   _params: GQLArticleTransformedContentArgs,
-  context: Context,
+  context: ContextWithLoaders,
 ): Promise<GQLTransformedArticleContent> => {
   const params = _params.transformArgs ?? {};
-  const subject = params.subjectId;
+  let subjectId = params.subjectId;
+  if (params.contextId && !subjectId) {
+    const contextNode = await context.loaders.nodesLoader.load({ contextId: params.contextId });
+    const contextRootId = contextNode[0]?.context?.rootId;
+    if (contextRootId) {
+      subjectId = contextRootId;
+    }
+  }
   const { content, metaData, visualElement, visualElementEmbed } = await transformArticle(
     article.content.content,
     context,
     article.visualElement?.visualElement,
     {
-      subject,
+      subject: subjectId,
       draftConcept: params.draftConcept,
       previewH5p: params.previewH5p,
       absoluteUrl: params.absoluteUrl,
@@ -49,17 +56,24 @@ export const fetchTransformedContent = async (
 export const fetchTransformedDisclaimer = async (
   article: IArticleV2DTO,
   _params: GQLArticleTransformedContentArgs,
-  context: Context,
+  context: ContextWithLoaders,
 ): Promise<GQLTransformedArticleContent> => {
   if (!article.disclaimer?.disclaimer) return { content: "" };
   const params = _params.transformArgs ?? {};
-  const subject = params.subjectId;
+  let subjectId = params.subjectId;
+  if (params.contextId && !subjectId) {
+    const contextNode = await context.loaders.nodesLoader.load({ contextId: params.contextId });
+    const contextRootId = contextNode[0]?.context?.rootId;
+    if (contextRootId) {
+      subjectId = contextRootId;
+    }
+  }
   const { content, metaData, visualElement, visualElementEmbed } = await transformArticle(
     article.disclaimer.disclaimer,
     context,
     undefined,
     {
-      subject,
+      subject: subjectId,
       draftConcept: params.draftConcept,
       previewH5p: params.previewH5p,
       absoluteUrl: params.absoluteUrl,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -724,6 +724,7 @@ export const typeDefs = gql`
 
   input TransformedArticleContentInput {
     subjectId: String
+    contextId: String
     isOembed: String
     showVisualElement: String
     path: String

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -2050,6 +2050,7 @@ export type GQLTransformedArticleContent = {
 
 export type GQLTransformedArticleContentInput = {
   absoluteUrl?: InputMaybe<Scalars['Boolean']['input']>;
+  contextId?: InputMaybe<Scalars['String']['input']>;
   draftConcept?: InputMaybe<Scalars['Boolean']['input']>;
   isOembed?: InputMaybe<Scalars['String']['input']>;
   path?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
Vi sender jo strengt tatt aldri med `subjectId` lenger, så vi må ha en annen lur måte å finne ut av hvilken kontekst vi er i