### PR TITLE
Add handling of undefined in url

### DIFF
--- a/src/api/externalApi.ts
+++ b/src/api/externalApi.ts
@@ -37,6 +37,6 @@ export const fetchOpengraph = async (url: string): Promise<GQLExternalOpengraph 
     description: ogs.result.ogDescription,
     imageUrl: ogs.result.ogImage?.[0]?.url,
     imageAlt: ogs.result.ogImage?.[0]?.alt,
-    url: ogs.result.ogUrl ?? url,
+    url: ogs.result.ogUrl === "undefined" ? url : ogs.result.ogUrl,
   };
 };


### PR DESCRIPTION
Av en eller anna grunn returnerer opengraph dette fra youtube innimellom:
```
{
   success: true,
   ogTitle: ' - YouTube',
   ogDescription: 'Med YouTube kan du se populære videoer, kose deg med favorittmusikken din og laste opp ditt eget innhold – og dele det med familie, venner og resten av verden.',
   ogLocale: 'nb-NO',
   ogUrl: 'undefined',
   favicon: 'https://www.youtube.com/s/desktop/ca191cfa/img/logos/favicon.ico',
   charset: 'UTF-8',
   requestUrl: 'https://youtu.be/H9TJNclSWBQ?si=P5NLUVtwyQi0n-eh'
 }
```

url som kalles er feks https://youtu.be/H9TJNclSWBQ?si=P5NLUVtwyQi0n-eh