### PR TITLE
refactor: openapi-fetch for ndla apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "marked": "^9.1.0",
     "node-fetch": "2.6.7",
     "open-graph-scraper": "^6.8.3",
+    "openapi-fetch": "^0.13.5",
     "prismjs": "^1.29.0",
     "prom-client": "^15.1.3",
     "query-string": "^6.2.0",

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -159,7 +159,7 @@ export async function fetchArticlesPage(
 
 export async function fetchArticles(articleIds: string[], context: Context): Promise<(IArticleV2DTO | undefined)[]> {
   const pageSize = 100;
-  const ids = articleIds.map(parseInt).filter((id) => isNaN(id) === false);
+  const ids = articleIds.map((id) => parseInt(id)).filter((id) => isNaN(id) === false);
   const numberOfPages = Math.ceil(ids.length / pageSize);
 
   const requests = [];

--- a/src/api/articleApi.ts
+++ b/src/api/articleApi.ts
@@ -6,17 +6,19 @@
  *
  */
 
-import { IArticleV2DTO } from "@ndla/types-backend/article-api";
+import { IArticleV2DTO, openapi } from "@ndla/types-backend/article-api";
 import { queryNodes } from "./taxonomyApi";
 import { transformArticle } from "./transformArticleApi";
 import { ndlaUrl } from "../config";
 import { GQLArticleTransformedContentArgs, GQLRelatedContent, GQLTransformedArticleContent } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { createAuthClient, fetch, resolveJson, resolveJsonOATS } from "../utils/apiHelpers";
 import { getArticleIdFromUrn } from "../utils/articleHelpers";
 
 interface ArticleParams {
   articleId: string;
 }
+
+const client = createAuthClient<openapi.paths>();
 
 export const fetchTransformedContent = async (
   article: IArticleV2DTO,

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -6,21 +6,59 @@
  *
  */
 
-import { IAudioMetaInformationDTO, IAudioSummarySearchResultDTO, ISeriesDTO } from "@ndla/types-backend/audio-api";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import {
+  IAudioMetaInformationDTO,
+  IAudioSummarySearchResultDTO,
+  ISeriesDTO,
+  openapi,
+  SeriesSummarySearchResultDTO,
+} from "@ndla/types-backend/audio-api";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+
+const client = createAuthClient<openapi.paths>();
+
+const getNumberId = (audioId: number | string): number => {
+  if (typeof audioId === "string") {
+    const numberId = parseInt(audioId);
+    if (isNaN(numberId)) {
+      throw new Error(`Invalid audioId: ${audioId}`);
+    }
+    return numberId;
+  }
+  return audioId;
+};
 
 export async function fetchAudio(context: Context, audioId: number | string): Promise<IAudioMetaInformationDTO | null> {
-  const response = await fetch(`/audio-api/v1/audio/${audioId}?language=${context.language}`, context);
+  const response = await client.GET("/audio-api/v1/audio/{audio-id}", {
+    params: {
+      path: {
+        "audio-id": getNumberId(audioId),
+      },
+      query: {
+        language: context.language,
+      },
+    },
+  });
   try {
-    return await resolveJson(response);
+    return await resolveJsonOATS(response);
   } catch (e) {
     return null;
   }
 }
 
 export async function fetchAudioV2(context: Context, audioId: number | string): Promise<IAudioMetaInformationDTO> {
-  const response = await fetch(`/audio-api/v1/audio/${audioId}?language=${context.language}`, context);
-  return await resolveJson(response);
+  return client
+    .GET("/audio-api/v1/audio/{audio-id}", {
+      params: {
+        path: {
+          "audio-id": getNumberId(audioId),
+        },
+        query: {
+          language: context.language,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function fetchPodcastsPage(
@@ -29,16 +67,32 @@ export async function fetchPodcastsPage(
   page: number,
   fallback: boolean,
 ): Promise<IAudioSummarySearchResultDTO> {
-  const response = await fetch(
-    `/audio-api/v1/audio/?page-size=${pageSize}&page=${page}&audio-type=podcast&language=${context.language}&fallback=${fallback}`,
-    context,
-  );
-  return await resolveJson(response);
+  return client
+    .GET("/audio-api/v1/audio", {
+      params: {
+        query: {
+          "page-size": pageSize,
+          page,
+          "audio-type": "podcast",
+          language: context.language,
+          fallback,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function fetchPodcastSeries(context: Context, podcastId: number): Promise<ISeriesDTO> {
-  const response = await fetch(`/audio-api/v1/series/${podcastId}?language=${context.language}`, context);
-  return await resolveJson(response);
+  return client
+    .GET("/audio-api/v1/series/{series-id}", {
+      params: {
+        path: {
+          "series-id": podcastId,
+        },
+        query: { language: context.language },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function fetchPodcastSeriesPage(
@@ -46,10 +100,17 @@ export async function fetchPodcastSeriesPage(
   pageSize: number,
   page: number,
   fallback: boolean,
-): Promise<IAudioSummarySearchResultDTO> {
-  const response = await fetch(
-    `/audio-api/v1/series/?page-size=${pageSize}&page=${page}&language=${context.language}&fallback=${fallback}`,
-    context,
-  );
-  return await resolveJson(response);
+): Promise<SeriesSummarySearchResultDTO> {
+  return client
+    .GET("/audio-api/v1/series", {
+      params: {
+        query: {
+          "page-size": pageSize,
+          page,
+          language: context.language,
+          fallback,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }

--- a/src/api/audioApi.ts
+++ b/src/api/audioApi.ts
@@ -14,19 +14,9 @@ import {
   SeriesSummarySearchResultDTO,
 } from "@ndla/types-backend/audio-api";
 import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+import { getNumberId } from "../utils/apiHelpers";
 
 const client = createAuthClient<openapi.paths>();
-
-const getNumberId = (audioId: number | string): number => {
-  if (typeof audioId === "string") {
-    const numberId = parseInt(audioId);
-    if (isNaN(numberId)) {
-      throw new Error(`Invalid audioId: ${audioId}`);
-    }
-    return numberId;
-  }
-  return audioId;
-};
 
 export async function fetchAudio(context: Context, audioId: number | string): Promise<IAudioMetaInformationDTO | null> {
   const response = await client.GET("/audio-api/v1/audio/{audio-id}", {

--- a/src/api/conceptApi.ts
+++ b/src/api/conceptApi.ts
@@ -8,19 +8,9 @@
 
 import { IConceptSearchResultDTO, IConceptDTO, openapi } from "@ndla/types-backend/concept-api";
 import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+import { getNumberId } from "../utils/apiHelpers";
 
 const client = createAuthClient<openapi.paths>();
-
-const getNumberId = (conceptId: number | string): number => {
-  if (typeof conceptId === "string") {
-    const numberId = parseInt(conceptId);
-    if (isNaN(numberId)) {
-      throw new Error(`Invalid conceptId: ${conceptId}`);
-    }
-    return numberId;
-  }
-  return conceptId;
-};
 
 export async function searchConcepts(
   params: {

--- a/src/api/externalApi.ts
+++ b/src/api/externalApi.ts
@@ -7,25 +7,22 @@
  */
 
 import { youtube } from "@googleapis/youtube";
-import queryString from "query-string";
 import { OembedEmbedData, OembedProxyData } from "@ndla/types-embed";
+import { openapi } from "@ndla/types-backend/oembed-proxy";
 import { googleApiKey } from "../config";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
 import openGraph from "open-graph-scraper";
 import { GQLExternalOpengraph } from "../types/schema";
+
+const client = createAuthClient<openapi.paths>();
 
 export const fetchExternalOembed = async (embed: OembedEmbedData, context: Context): Promise<OembedProxyData> => {
   return await fetchOembedUrl(embed.url, context);
 };
 
-export const fetchOembedUrl = async (url: string, context: Context): Promise<OembedProxyData> => {
-  const res = await fetch(
-    `/oembed-proxy/v1/oembed?${queryString.stringify({
-      url,
-    })}`,
-    context,
-  );
-  return await resolveJson(res);
+export const fetchOembedUrl = async (url: string, _context: Context): Promise<OembedProxyData> => {
+  const response = await client.GET("/oembed-proxy/v1/oembed", { params: { query: { url } } }).then(resolveJsonOATS);
+  return { ...response, type: "proxy" };
 };
 
 export const getYoutubeVideoId = (url: string) => {

--- a/src/api/fileApi.ts
+++ b/src/api/fileApi.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { fetch } from "../utils/apiHelpers";
+import { fetch } from "../utils/fetch";
 
 export const checkIfFileExists = async (fileUrl: string, context: Context): Promise<boolean> => {
   const response = await fetch(fileUrl, context, { method: "HEAD" });

--- a/src/api/folderResourceMetaApi.ts
+++ b/src/api/folderResourceMetaApi.ts
@@ -27,6 +27,7 @@ import {
   GQLQueryFolderResourceMetaSearchArgs,
 } from "../types/schema";
 import { articleToMeta, learningpathToMeta } from "../utils/apiHelpers";
+import getLogger from "../utils/logger";
 
 const findResourceTypes = (result: Node | null, context: ContextWithLoaders): GQLFolderResourceResourceType[] => {
   const ctx = result?.contexts?.[0];
@@ -44,7 +45,8 @@ const fetchResourceMeta = async (
   context: ContextWithLoaders,
 ): Promise<Array<GQLMeta | undefined>> => {
   if (type === "learningpath") {
-    const learningpaths = await context.loaders.learningpathsLoader.loadMany(ids);
+    const numberIds = ids.map((id) => parseInt(id)).filter((id) => !!id);
+    const learningpaths = await context.loaders.learningpathsLoader.loadMany(numberIds);
     return learningpaths
       .filter((learningpath): learningpath is ILearningPathV2DTO => !!learningpath)
       .map(learningpathToMeta);
@@ -80,8 +82,7 @@ const fetchAndTransformResourceMeta = async (
       };
     });
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(`Failed to fetch article metas with parameters ${resources}`);
+    getLogger().error(`Failed to fetch article metas with parameters: ${JSON.stringify(resources)}`, resources);
     return [];
   }
 };

--- a/src/api/frontpageApi.ts
+++ b/src/api/frontpageApi.ts
@@ -6,8 +6,10 @@
  *
  */
 
-import { IFrontPageDTO, IFilmFrontPageDTO, ISubjectPageDTO } from "@ndla/types-backend/frontpage-api";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { openapi, IFrontPageDTO, IFilmFrontPageDTO, ISubjectPageDTO } from "@ndla/types-backend/frontpage-api";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+
+const client = createAuthClient<openapi.paths>();
 
 export interface IMovieMeta {
   title: string;
@@ -19,20 +21,26 @@ export interface IMovieMeta {
   };
 }
 
-export async function fetchFrontpage(context: Context): Promise<IFrontPageDTO> {
-  const response = await fetch(`/frontpage-api/v1/frontpage`, context);
-  return await resolveJson(response);
+export async function fetchFrontpage(_context: Context): Promise<IFrontPageDTO> {
+  return client.GET("/frontpage-api/v1/frontpage").then(resolveJsonOATS);
 }
 
 export async function fetchSubjectPage(subjectPageId: number, context: Context): Promise<ISubjectPageDTO> {
-  const response = await fetch(
-    `/frontpage-api/v1/subjectpage/${subjectPageId}?language=${context.language}&fallback=true`,
-    context,
-  );
-  return await resolveJson(response);
+  return client
+    .GET("/frontpage-api/v1/subjectpage/{subjectpage-id}", {
+      params: {
+        path: {
+          "subjectpage-id": subjectPageId,
+        },
+        query: {
+          language: context.language,
+          fallback: true,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
-export async function fetchFilmFrontpage(context: Context): Promise<IFilmFrontPageDTO> {
-  const response = await fetch(`/frontpage-api/v1/filmfrontpage`, context);
-  return await resolveJson(response);
+export async function fetchFilmFrontpage(_context: Context): Promise<IFilmFrontPageDTO> {
+  return client.GET("/frontpage-api/v1/filmfrontpage").then(resolveJsonOATS);
 }

--- a/src/api/h5pApi.ts
+++ b/src/api/h5pApi.ts
@@ -16,7 +16,8 @@ import {
   H5pInfo,
 } from "@ndla/types-embed";
 import { h5pHostUrl } from "../config";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { resolveJson } from "../utils/apiHelpers";
+import { fetch } from "../utils/fetch";
 
 const fetchPreviewOembed = async (embed: H5pEmbedData, context: Context): Promise<H5pPreviewResponse> => {
   const url = `${h5pHostUrl()}/oembed/preview?${queryString.stringify({

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -14,19 +14,9 @@ import {
 } from "@ndla/types-backend/image-api";
 import { GQLImageLicense, GQLQueryImageSearchArgs } from "../types/schema";
 import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+import { getNumberId } from "../utils/apiHelpers";
 
 const client = createAuthClient<openapi.paths>();
-
-const getNumberId = (imageId: number | string): number => {
-  if (typeof imageId === "string") {
-    const numberId = parseInt(imageId);
-    if (isNaN(numberId)) {
-      throw new Error(`Invalid imageId: ${imageId}`);
-    }
-    return numberId;
-  }
-  return imageId;
-};
 
 export async function fetchImage(imageId: string, context: Context): Promise<IImageMetaInformationV2DTO | null> {
   const response = await client.GET("/image-api/v2/images/{image_id}", {

--- a/src/api/imageApi.ts
+++ b/src/api/imageApi.ts
@@ -6,40 +6,73 @@
  *
  */
 
-import qs from "query-string";
 import {
+  openapi,
   IImageMetaInformationV2DTO,
   IImageMetaInformationV3DTO,
   ISearchResultV3DTO,
 } from "@ndla/types-backend/image-api";
 import { GQLImageLicense, GQLQueryImageSearchArgs } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+
+const client = createAuthClient<openapi.paths>();
+
+const getNumberId = (imageId: number | string): number => {
+  if (typeof imageId === "string") {
+    const numberId = parseInt(imageId);
+    if (isNaN(numberId)) {
+      throw new Error(`Invalid imageId: ${imageId}`);
+    }
+    return numberId;
+  }
+  return imageId;
+};
 
 export async function fetchImage(imageId: string, context: Context): Promise<IImageMetaInformationV2DTO | null> {
-  const languageParam = context.language ? `?language=${context.language}` : "";
-  const response = await fetch(`/image-api/v2/images/${imageId}${languageParam}`, context);
+  const response = await client.GET("/image-api/v2/images/{image_id}", {
+    params: {
+      path: {
+        image_id: getNumberId(imageId),
+      },
+      query: {
+        language: context.language,
+      },
+    },
+  });
+
   try {
-    return await resolveJson(response);
+    return await resolveJsonOATS(response);
   } catch (e) {
     return null;
   }
 }
 
 export async function fetchImageV3(imageId: number | string, context: Context): Promise<IImageMetaInformationV3DTO> {
-  const languageParam = context.language ? `?language=${context.language}` : "";
-  const response = await fetch(`/image-api/v3/images/${imageId}${languageParam}`, context);
-  return await resolveJson(response);
+  return client
+    .GET("/image-api/v3/images/{image_id}", {
+      params: {
+        path: {
+          image_id: getNumberId(imageId),
+        },
+        query: { language: context.language },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
-export async function searchImages(params: GQLQueryImageSearchArgs, context: Context): Promise<ISearchResultV3DTO> {
-  const queryStr = qs.stringify({
-    "page-size": params.pageSize,
-    license: params.license,
-    page: params.page,
-    query: params.query,
-  });
-  const response = await fetch(`/image-api/v3/images?${queryStr}`, context);
-  return await resolveJson(response);
+export async function searchImages(params: GQLQueryImageSearchArgs, _context: Context): Promise<ISearchResultV3DTO> {
+  return client
+    .GET("/image-api/v3/images", {
+      params: {
+        query: {
+          "page-size": params.pageSize,
+          license: params.license,
+          page: params.page,
+          query: params.query,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export function convertToSimpleImage(image: IImageMetaInformationV2DTO) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,7 +12,7 @@ export { fetchImage, fetchImageV3 } from "./imageApi";
 export { fetchFrontpage, fetchSubjectPage, fetchFilmFrontpage } from "./frontpageApi";
 export { fetchLearningpaths, fetchMyLearningpaths, fetchLearningpath } from "./learningpathApi";
 export { fetchOembed } from "./oembedApi";
-export { search, groupSearch, searchWithoutPagination } from "./searchApi";
+export { search, searchWithoutPagination } from "./searchApi";
 export {
   fetchResourceTypes,
   fetchSubjectTopics,

--- a/src/api/learningpathApi.ts
+++ b/src/api/learningpathApi.ts
@@ -19,19 +19,9 @@ import {
   GQLMutationUpdateLearningpathStepSeqNoArgs,
 } from "../types/schema";
 import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+import { getNumberId } from "../utils/apiHelpers";
 
 const client = createAuthClient<openapi.paths>();
-
-const getNumberId = (id: number | string): number => {
-  if (typeof id === "string") {
-    const numberId = parseInt(id);
-    if (isNaN(numberId)) {
-      throw new Error(`Invalid leanringpathId: ${id}`);
-    }
-    return numberId;
-  }
-  return id;
-};
 
 export async function fetchLearningpaths(
   learningpathIds: number[],

--- a/src/api/learningpathApi.ts
+++ b/src/api/learningpathApi.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import { ILearningPathV2DTO, ILearningStepV2DTO } from "@ndla/types-backend/learningpath-api";
+import { openapi, ILearningPathV2DTO, ILearningStepV2DTO, AuthorDTO } from "@ndla/types-backend/learningpath-api";
 import {
   GQLLearningpathSeqNo,
   GQLMutationCopyLearningpathArgs,
@@ -18,145 +18,198 @@ import {
   GQLMutationUpdateLearningpathStepArgs,
   GQLMutationUpdateLearningpathStepSeqNoArgs,
 } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
+
+const client = createAuthClient<openapi.paths>();
+
+const getNumberId = (id: number | string): number => {
+  if (typeof id === "string") {
+    const numberId = parseInt(id);
+    if (isNaN(numberId)) {
+      throw new Error(`Invalid leanringpathId: ${id}`);
+    }
+    return numberId;
+  }
+  return id;
+};
 
 export async function fetchLearningpaths(
-  learningpathIds: string[],
+  learningpathIds: number[],
   context: Context,
 ): Promise<Array<ILearningPathV2DTO | undefined>> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/ids?language=${context.language}&ids=${learningpathIds.join(",")}`,
-    context,
-  );
-  const json: ILearningPathV2DTO[] = await resolveJson(response);
+  const json = await client
+    .GET("/learningpath-api/v2/learningpaths/ids", {
+      params: {
+        query: {
+          ids: learningpathIds,
+          language: context.language,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
   // The api does not always return the exact number of results as ids provided.
   // So always map over ids so that dataLoader gets the right amount of results in correct order.
   return learningpathIds.map((id) => {
     const learningpath = json.find((item) => {
-      return item.id.toString() === id;
+      return item.id === id;
     });
     return learningpath;
   });
 }
 
-export async function fetchMyLearningpaths(context: Context): Promise<Array<ILearningPathV2DTO>> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/mine?language=${context.language}&fallback=true`,
-    context,
-  );
-  return await resolveJson(response);
+export async function fetchMyLearningpaths(_context: Context): Promise<Array<ILearningPathV2DTO>> {
+  return client.GET("/learningpath-api/v2/learningpaths/mine").then(resolveJsonOATS);
 }
 
 export async function fetchLearningpath(id: string, context: Context): Promise<ILearningPathV2DTO> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/${id}?language=${context.language}&fallback=true`,
-    context,
-  );
-  return await resolveJson(response);
+  return client
+    .GET("/learningpath-api/v2/learningpaths/{learningpath_id}", {
+      params: {
+        path: {
+          learningpath_id: getNumberId(id),
+        },
+        query: {
+          language: context.language,
+          fallback: true,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function updateLearningpathStatus(
   { id, status }: GQLMutationUpdateLearningpathStatusArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningPathV2DTO> {
-  const response = await fetch(`/learningpath-api/v2/learningpaths/${id}/status`, context, {
-    method: "PUT",
-    body: JSON.stringify({ status: status }),
-  });
-  return await resolveJson(response);
+  return client
+    .PUT("/learningpath-api/v2/learningpaths/{learningpath_id}/status", {
+      params: { path: { learningpath_id: id } },
+      body: { status },
+    })
+    .then(resolveJsonOATS);
 }
 
-export async function deleteLearningpath(id: number, context: Context): Promise<boolean> {
-  const response = await fetch(`/learningpath-api/v2/learningpaths/${id}`, context, {
-    method: "DELETE",
+export async function deleteLearningpath(id: number, _context: Context): Promise<boolean> {
+  const { response } = await client.DELETE("/learningpath-api/v2/learningpaths/{learningpath_id}", {
+    params: { path: { learningpath_id: id } },
   });
   return response.ok;
 }
 
 export async function createLearningpath(
   { params }: GQLMutationNewLearningpathArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningPathV2DTO> {
-  const response = await fetch("/learningpath-api/v2/learningpaths", context, {
-    method: "POST",
-    body: JSON.stringify(params),
-  });
-  return await resolveJson(response);
+  return client
+    .POST("/learningpath-api/v2/learningpaths", {
+      body: {
+        ...params,
+        copyright: {
+          ...params.copyright,
+          contributors: params.copyright.contributors as AuthorDTO[],
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function updateLearningpath(
   { learningpathId, params }: GQLMutationUpdateLearningpathArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningPathV2DTO> {
-  const response = await fetch(`/learningpath-api/v2/learningpaths/${learningpathId}`, context, {
-    method: "PATCH",
-    body: JSON.stringify(params),
-  });
-  return await resolveJson(response);
+  const copyright = params.copyright
+    ? {
+        ...params.copyright,
+        contributors: params.copyright?.contributors as AuthorDTO[],
+      }
+    : undefined;
+  return client
+    .PATCH("/learningpath-api/v2/learningpaths/{learningpath_id}", {
+      params: { path: { learningpath_id: learningpathId } },
+      body: {
+        ...params,
+        copyright,
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function createLearningstep(
   { learningpathId, params }: GQLMutationNewLearningpathStepArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningStepV2DTO> {
-  const response = await fetch(`/learningpath-api/v2/learningpaths/${learningpathId}/learningsteps`, context, {
-    method: "POST",
-    body: JSON.stringify(params),
-  });
-  return await resolveJson(response);
+  return client
+    .POST("/learningpath-api/v2/learningpaths/{learningpath_id}/learningsteps", {
+      params: { path: { learningpath_id: learningpathId } },
+      body: params,
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function updateLearningstep(
   { learningpathId, learningstepId, params }: GQLMutationUpdateLearningpathStepArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningStepV2DTO> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/${learningpathId}/learningsteps/${learningstepId}`,
-    context,
-    {
-      method: "PATCH",
-      body: JSON.stringify(params),
-    },
-  );
-  return await resolveJson(response);
+  return client
+    .PATCH("/learningpath-api/v2/learningpaths/{learningpath_id}/learningsteps/{learningstep_id}", {
+      params: {
+        path: {
+          learningpath_id: learningpathId,
+          learningstep_id: learningstepId,
+        },
+      },
+      body: params,
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function deleteLearningstep(
   { learningstepId, learningpathId }: GQLMutationDeleteLearningpathStepArgs,
-  context: Context,
+  _context: Context,
 ): Promise<string[]> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/${learningpathId}/learningsteps/${learningstepId}`,
-    context,
-    {
-      method: "DELETE",
-    },
-  );
-  return await resolveJson(response);
+  return client
+    .DELETE("/learningpath-api/v2/learningpaths/{learningpath_id}/learningsteps/{learningstep_id}", {
+      params: {
+        path: {
+          learningpath_id: learningpathId,
+          learningstep_id: learningstepId,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function copyLearningpath(
   { learningpathId, params }: GQLMutationCopyLearningpathArgs,
-  context: Context,
+  _context: Context,
 ): Promise<ILearningPathV2DTO> {
-  const response = await fetch(`/learningpath-api/v2/learningpaths/${learningpathId}/copy`, context, {
-    method: "POST",
-    body: JSON.stringify(params),
-  });
-  return await resolveJson(response);
+  const copyright = params.copyright
+    ? { ...params.copyright, contributors: params.copyright.contributors as AuthorDTO[] }
+    : undefined;
+  return client
+    .POST("/learningpath-api/v2/learningpaths/{learningpath_id}/copy", {
+      body: {
+        ...params,
+        copyright,
+      },
+      params: { path: { learningpath_id: learningpathId } },
+    })
+    .then(resolveJsonOATS);
 }
 
 export async function updateLearningpathStepSeqNo(
   { learningpathId, learningpathStepId, seqNo }: GQLMutationUpdateLearningpathStepSeqNoArgs,
-  context: Context,
+  _context: Context,
 ): Promise<GQLLearningpathSeqNo> {
-  const response = await fetch(
-    `/learningpath-api/v2/learningpaths/${learningpathId}/learningsteps/${learningpathStepId}/seqNo`,
-    context,
-    {
-      method: "PUT",
-      body: JSON.stringify({ seqNo: seqNo }),
-    },
-  );
-  return await resolveJson(response);
+  return client
+    .PUT("/learningpath-api/v2/learningpaths/{learningpath_id}/learningsteps/{learningstep_id}/seqNo", {
+      body: { seqNo },
+      params: {
+        path: {
+          learningpath_id: learningpathId,
+          learningstep_id: learningpathStepId,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 }

--- a/src/api/learningpathApi.ts
+++ b/src/api/learningpathApi.ts
@@ -22,6 +22,7 @@ import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils"
 import { getNumberId } from "../utils/apiHelpers";
 
 const client = createAuthClient<openapi.paths>();
+const cachelessClient = createAuthClient<openapi.paths>({ disableCache: true });
 
 export async function fetchLearningpaths(
   learningpathIds: number[],
@@ -48,7 +49,7 @@ export async function fetchLearningpaths(
 }
 
 export async function fetchMyLearningpaths(_context: Context): Promise<Array<ILearningPathV2DTO>> {
-  return client.GET("/learningpath-api/v2/learningpaths/mine").then(resolveJsonOATS);
+  return cachelessClient.GET("/learningpath-api/v2/learningpaths/mine").then(resolveJsonOATS);
 }
 
 export async function fetchLearningpath(id: string, context: Context): Promise<ILearningPathV2DTO> {

--- a/src/api/myndlaApi.ts
+++ b/src/api/myndlaApi.ts
@@ -6,13 +6,21 @@
  *
  */
 
-import { IConfigMetaRestrictedDTO } from "@ndla/types-backend/myndla-api";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { IConfigMetaRestrictedDTO, openapi, ConfigKey } from "@ndla/types-backend/myndla-api";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
 
-export const fetchConfig = async (configKey: string, context: Context): Promise<IConfigMetaRestrictedDTO> => {
-  const response = await fetch(`/myndla-api/v1/config/${configKey}`, context);
-  const config: IConfigMetaRestrictedDTO = await resolveJson(response);
-  return config;
+const client = createAuthClient<openapi.paths>();
+
+export const fetchConfig = async (configKey: string, _context: Context): Promise<IConfigMetaRestrictedDTO> => {
+  return client
+    .GET("/myndla-api/v1/config/{config-key}", {
+      params: {
+        path: {
+          "config-key": configKey as ConfigKey,
+        },
+      },
+    })
+    .then(resolveJsonOATS);
 };
 
 export const fetchExamLockStatus = async (context: Context): Promise<IConfigMetaRestrictedDTO> =>

--- a/src/api/oembedApi.ts
+++ b/src/api/oembedApi.ts
@@ -6,18 +6,13 @@
  *
  */
 
-import { GQLH5pElement, GQLLearningpathStepOembed, GQLVisualElementOembed } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { openapi, OEmbedDTO } from "@ndla/types-backend/oembed-proxy";
+import { createAuthClient, resolveJsonOATS } from "../utils/openapi-fetch/utils";
 
-export async function fetchOembed<T extends GQLLearningpathStepOembed | GQLH5pElement | GQLVisualElementOembed>(
-  url: string,
-  context: Context,
-): Promise<T> {
-  return await fetch(`/oembed-proxy/v1/oembed?url=${url}`, context)
-    .then((r) => resolveJson(r))
-    .catch((e) => {
-      if (e.status === 404) {
-        return null;
-      } else throw e;
-    });
+const client = createAuthClient<openapi.paths>();
+
+export async function fetchOembed(url: string, _context: Context): Promise<OEmbedDTO | null> {
+  const result = await client.GET("/oembed-proxy/v1/oembed", { params: { query: { url } } });
+  if (result.response.status === 404) return null;
+  return resolveJsonOATS(result);
 }

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -36,7 +36,9 @@ function commaSeparatedStringToArray(input: string | string[] | undefined): stri
   return input.split(",").map((s) => s.trim());
 }
 
-const convertQuery = (searchQuery: GQLQuerySearchArgs) => {
+type SearchQueryParams = openapi.operations["getSearch-apiV1Search"]["parameters"]["query"];
+
+const convertQuery = (searchQuery: GQLQuerySearchArgs): SearchQueryParams => {
   return {
     ...searchQuery,
     "page-size": searchQuery.pageSize,

--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -8,6 +8,7 @@
 
 import queryString from "query-string";
 import {
+  openapi,
   IGrepSearchInputDTO,
   IGrepSearchResultsDTO,
   IGroupSearchResultDTO,

--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -10,7 +10,8 @@ import { Response } from "node-fetch";
 import qs from "query-string";
 import { Node, NodeChild, TaxonomyContext, Version, SearchResult } from "@ndla/types-taxonomy";
 import { GQLResourceType, GQLResourceTypeDefinition, GQLSubject, GQLTopic } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { resolveJson } from "../utils/apiHelpers";
+import { fetch } from "../utils/fetch";
 
 async function taxonomyFetch(path: string, context: Context, options?: RequestOptions): Promise<Response> {
   return fetch(path, context, { ...options, useTaxonomyCache: true });

--- a/src/api/uptimeApi.ts
+++ b/src/api/uptimeApi.ts
@@ -9,7 +9,8 @@
 import he from "he";
 import { ndlaEnvironment, uptimeOwner, uptimeRepo, uptimeToken } from "../config";
 import { GQLUptimeAlert } from "../types/schema";
-import { fetch, resolveJson } from "../utils/apiHelpers";
+import { resolveJson } from "../utils/apiHelpers";
+import { fetch } from "../utils/fetch";
 import parseMarkdown from "../utils/parseMarkdown";
 
 interface GithubLabel {

--- a/src/api/videoApi.ts
+++ b/src/api/videoApi.ts
@@ -8,7 +8,8 @@
 
 import { BrightcoveApiType, BrightcoveVideoSource } from "@ndla/types-embed";
 import { getEnvironmentVariabel } from "../config";
-import { resolveJson, fetch } from "../utils/apiHelpers";
+import { resolveJson } from "../utils/apiHelpers";
+import { fetch } from "../utils/fetch";
 
 const b64EncodeUnicode = (str: string) =>
   btoa(encodeURIComponent(str).replace(/%([0-9A-F]{2})/g, (_, p1) => String.fromCharCode(Number(`0x${p1}`))));

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,7 +9,7 @@
 import { Request } from "express";
 import isString from "lodash/isString";
 
-export async function getToken(request: Request): Promise<AuthToken | undefined> {
+export function getToken(request: Request): AuthToken | undefined {
   const authorization = request.headers.authorization;
 
   if (isString(authorization)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,7 @@ export function getEnvironmentVariabel(key: string, fallback?: string | boolean)
 }
 
 export const ndlaEnvironment = getEnvironmentVariabel("NDLA_ENVIRONMENT", "test");
+export const environmentApiHost = `api.${ndlaEnvironment.toString().replace("_", "-")}.ndla.no`;
 
 const ndlaApiUrl = () => {
   const host = getEnvironmentVariabel("API_GATEWAY_HOST");
@@ -29,7 +30,7 @@ const ndlaApiUrl = () => {
       case "prod":
         return "https://api.ndla.no";
       default:
-        return `https://api.${ndlaEnvironment.toString().replace("_", "-")}.ndla.no`;
+        return `https://${environmentApiHost}`;
     }
   } else {
     return `http://${host}`;
@@ -61,6 +62,7 @@ export const h5pHostUrl = () => {
   }
 };
 
+export const cacheTime = getEnvironmentVariabel("CACHE_TIME", "60");
 export const defaultLanguage = getEnvironmentVariabel("DEFAULT_LANGUAGE", "nb");
 export const port = getEnvironmentVariabel("PORT", "4000");
 export const apiUrl = getEnvironmentVariabel("API_URL", ndlaApiUrl());

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -35,12 +35,9 @@ export function articlesLoader(context: Context): DataLoader<string, IArticleV2D
   );
 }
 
-export function learningpathsLoader(context: Context): DataLoader<string, ILearningPathV2DTO | undefined> {
+export function learningpathsLoader(context: Context): DataLoader<number, ILearningPathV2DTO | undefined> {
   return new DataLoader(async (learningpathIds) => {
-    return fetchLearningpaths(
-      learningpathIds.map((id) => parseInt(id)),
-      context,
-    );
+    return fetchLearningpaths(learningpathIds, context);
   });
 }
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -37,7 +37,10 @@ export function articlesLoader(context: Context): DataLoader<string, IArticleV2D
 
 export function learningpathsLoader(context: Context): DataLoader<string, ILearningPathV2DTO | undefined> {
   return new DataLoader(async (learningpathIds) => {
-    return fetchLearningpaths(learningpathIds.map(parseInt), context);
+    return fetchLearningpaths(
+      learningpathIds.map((id) => parseInt(id)),
+      context,
+    );
   });
 }
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -37,7 +37,7 @@ export function articlesLoader(context: Context): DataLoader<string, IArticleV2D
 
 export function learningpathsLoader(context: Context): DataLoader<string, ILearningPathV2DTO | undefined> {
   return new DataLoader(async (learningpathIds) => {
-    return fetchLearningpaths(learningpathIds, context);
+    return fetchLearningpaths(learningpathIds.map(parseInt), context);
   });
 }
 

--- a/src/resolvers/articleResolvers.ts
+++ b/src/resolvers/articleResolvers.ts
@@ -22,7 +22,6 @@ import {
   GQLTransformedArticleContent,
   GQLArticleTransformedContentArgs,
   GQLRelatedContent,
-  GQLVisualElementOembed,
   GQLMetaImageWithCopyright,
 } from "../types/schema";
 
@@ -99,8 +98,8 @@ export const resolvers = {
       return [];
     },
     async oembed(article: IArticleV2DTO, _: any, context: ContextWithLoaders): Promise<string | undefined> {
-      const oembed = await fetchOembed<GQLVisualElementOembed>(`${ndlaUrl}/article/${article.id}`, context);
-      if (oembed.html === undefined) return undefined;
+      const oembed = await fetchOembed(`${ndlaUrl}/article/${article.id}`, context);
+      if (oembed?.html === undefined) return undefined;
       const parsed = load(oembed.html);
       return parsed("iframe").attr("src");
     },

--- a/src/resolvers/learningpathResolvers.ts
+++ b/src/resolvers/learningpathResolvers.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { OEmbedDTO } from "@ndla/types-backend/oembed-proxy";
 import { fetchImageV3, fetchLearningpath, fetchMyLearningpaths, fetchNode, fetchOembed } from "../api";
 import { fetchOpengraph } from "../api/externalApi";
 import {
@@ -82,7 +83,7 @@ const getOembed = async (
   learningpathStep: GQLLearningpathStep,
   _: any,
   context: ContextWithLoaders,
-): Promise<GQLLearningpathStepOembed | null> => {
+): Promise<OEmbedDTO | null> => {
   if (!learningpathStep.embedUrl || !learningpathStep.embedUrl.url) {
     return null;
   }
@@ -94,7 +95,7 @@ const getOembed = async (
     learningpathStep.embedUrl.embedType === "oembed" &&
     learningpathStep.embedUrl.url !== "https://ndla.no"
   ) {
-    return fetchOembed<GQLLearningpathStepOembed>(learningpathStep.embedUrl.url, context);
+    return fetchOembed(learningpathStep.embedUrl.url, context);
   }
   return null;
 };

--- a/src/resolvers/podcastResolvers.ts
+++ b/src/resolvers/podcastResolvers.ts
@@ -11,6 +11,7 @@ import {
   IAudioSummarySearchResultDTO,
   IPodcastMetaDTO,
   ISeriesDTO,
+  SeriesSummarySearchResultDTO,
 } from "@ndla/types-backend/audio-api";
 import { fetchAudio, fetchPodcastSeries, fetchPodcastSeriesPage, fetchPodcastsPage } from "../api/audioApi";
 import { fetchImage } from "../api/imageApi";
@@ -47,7 +48,7 @@ export const Query = {
     _: any,
     { pageSize, page, fallback }: GQLQueryPodcastSeriesSearchArgs,
     context: ContextWithLoaders,
-  ): Promise<IAudioSummarySearchResultDTO> {
+  ): Promise<SeriesSummarySearchResultDTO> {
     return fetchPodcastSeriesPage(context, pageSize, page, fallback ?? false);
   },
 };

--- a/src/resolvers/resourceResolvers.ts
+++ b/src/resolvers/resourceResolvers.ts
@@ -66,9 +66,10 @@ export const resolvers = {
     },
     async meta(resource: GQLResource, _: any, context: ContextWithLoaders): Promise<GQLMeta | null> {
       if (resource.contentUri?.startsWith("urn:learningpath")) {
-        const learningpath = await context.loaders.learningpathsLoader.load(
-          resource.contentUri.replace("urn:learningpath:", ""),
-        );
+        const learningpathId = parseInt(getLearningpathIdFromUrn(resource.contentUri));
+        const learningpath = isNaN(learningpathId)
+          ? undefined
+          : await context.loaders.learningpathsLoader.load(learningpathId);
         return learningpath ? learningpathToMeta(learningpath) : null;
       } else if (resource.contentUri?.startsWith("urn:article")) {
         const article = await context.loaders.articlesLoader.load(getArticleIdFromUrn(resource.contentUri));

--- a/src/resolvers/searchResolvers.ts
+++ b/src/resolvers/searchResolvers.ts
@@ -6,9 +6,8 @@
  *
  */
 
-import { search, groupSearch, searchWithoutPagination } from "../api";
+import { search, searchWithoutPagination } from "../api";
 import {
-  GQLGroupSearch,
   GQLQuerySearchArgs,
   GQLQuerySearchWithoutPaginationArgs,
   GQLSearch,
@@ -18,9 +17,6 @@ import {
 export const Query = {
   async search(_: any, searchQuery: GQLQuerySearchArgs, context: ContextWithLoaders): Promise<GQLSearch> {
     return search(searchQuery, context);
-  },
-  async groupSearch(_: any, searchQuery: GQLQuerySearchArgs, context: ContextWithLoaders): Promise<GQLGroupSearch> {
-    return groupSearch(searchQuery, context);
   },
   async searchWithoutPagination(
     _: any,

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1509,7 +1509,7 @@ export const typeDefs = gql`
     folderResourceMeta(resource: FolderResourceMetaSearchInput!): FolderResourceMeta
     folderResourceMetaSearch(resources: [FolderResourceMetaSearchInput!]!): [FolderResourceMeta!]!
     folder(id: String!, includeSubfolders: Boolean, includeResources: Boolean): Folder!
-    sharedFolder(id: String!, includeSubfolders: Boolean, includeResources: Boolean): SharedFolder!
+    sharedFolder(id: String!): SharedFolder!
     allFolderResources(size: Int): [FolderResource!]!
     personalData: MyNdlaPersonalData
     image(id: String!): ImageMetaInformationV2

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,7 +18,8 @@ import { typeDefs } from "./schema";
 import correlationIdMiddleware from "./utils/correlationIdMiddleware";
 import { logError } from "./utils/logger";
 import loggerMiddleware from "./utils/loggerMiddleware";
-import { contextExpressMiddleware, getContextOrThrow } from "./utils/contextMiddleware";
+import { contextExpressMiddleware } from "./utils/context/contextMiddleware";
+import { getContextOrThrow } from "./utils/context/contextStore";
 
 const GRAPHQL_PORT = port;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,28 +10,15 @@ import compression from "compression";
 import cors from "cors";
 import express, { json, Request, Response } from "express";
 import promBundle from "express-prom-bundle";
-import isString from "lodash/isString";
 import { ApolloServer } from "@apollo/server";
 import { expressMiddleware } from "@apollo/server/express4";
-import { getToken } from "./auth";
-import { defaultLanguage, port } from "./config";
-import {
-  articlesLoader,
-  subjectTopicsLoader,
-  resourceTypesLoader,
-  learningpathsLoader,
-  subjectsLoader,
-  frontpageLoader,
-  subjectpageLoader,
-  nodeLoader,
-  nodesLoader,
-  searchNodesLoader,
-} from "./loaders";
+import { port } from "./config";
 import { resolvers } from "./resolvers";
 import { typeDefs } from "./schema";
 import correlationIdMiddleware from "./utils/correlationIdMiddleware";
 import { logError } from "./utils/logger";
 import loggerMiddleware from "./utils/loggerMiddleware";
+import { contextExpressMiddleware, getContextOrThrow } from "./utils/contextMiddleware";
 
 const GRAPHQL_PORT = port;
 
@@ -48,84 +35,6 @@ app.use(metricsMiddleware);
 // compress all responses
 app.use(compression());
 app.use(express.json({ limit: "1mb" }));
-
-function getAcceptLanguage(request: Request): string {
-  const language = request.headers["accept-language"];
-
-  if (isString(language)) {
-    return language.split("-")[0] ?? defaultLanguage;
-  }
-  return defaultLanguage;
-}
-
-function getHeaderString(request: Request, name: string): string | undefined {
-  const header = request.headers[name];
-
-  if (isString(header)) {
-    return header;
-  }
-  return undefined;
-}
-
-function getFeideAuthorization(request: Request): string | undefined {
-  return getHeaderString(request, "feideauthorization");
-}
-
-function getVersionHash(request: Request): string | undefined {
-  return getHeaderString(request, "versionhash");
-}
-
-function getShouldUseCache(request: Request): boolean {
-  const cacheControl = request.headers["cache-control"]?.toLowerCase();
-  const feideAuthHeader = getFeideAuthorization(request);
-  const disableCacheHeaders = ["no-cache", "no-store"];
-
-  const cacheControlDisable = disableCacheHeaders.includes(cacheControl ?? "");
-  const feideHeaderPresent = !!feideAuthHeader;
-
-  return !cacheControlDisable && !feideHeaderPresent;
-}
-
-const getTaxonomyUrl = (request: Request): string => {
-  const taxonomyUrl = request.headers["use-taxonomy2"];
-  return taxonomyUrl === "true" ? "taxonomy2" : "taxonomy";
-};
-
-async function getContext({ req, res }: { req: Request; res: Response }): Promise<ContextWithLoaders> {
-  const token = await getToken(req);
-  const feideAuthorization = getFeideAuthorization(req);
-  const versionHash = getVersionHash(req);
-
-  const language = getAcceptLanguage(req);
-  const shouldUseCache = getShouldUseCache(req);
-  const taxonomyUrl = getTaxonomyUrl(req);
-  const defaultContext = {
-    language,
-    token,
-    feideAuthorization,
-    versionHash,
-    shouldUseCache,
-    taxonomyUrl,
-    req,
-    res,
-  };
-
-  return {
-    ...defaultContext,
-    loaders: {
-      articlesLoader: articlesLoader(defaultContext),
-      subjectTopicsLoader: subjectTopicsLoader(defaultContext),
-      learningpathsLoader: learningpathsLoader(defaultContext),
-      resourceTypesLoader: resourceTypesLoader(defaultContext),
-      nodeLoader: nodeLoader(defaultContext),
-      nodesLoader: nodesLoader(defaultContext),
-      subjectsLoader: subjectsLoader(defaultContext),
-      frontpageLoader: frontpageLoader(defaultContext),
-      subjectpageLoader: subjectpageLoader(defaultContext),
-      searchNodesLoader: searchNodesLoader(defaultContext),
-    },
-  };
-}
 
 app.get("/health", (_: Request, res: Response) => {
   res.status(200).json({ status: 200, text: "Health check ok" });
@@ -156,8 +65,9 @@ async function startApolloServer() {
     cors(),
     json(),
     correlationIdMiddleware,
+    contextExpressMiddleware,
     loggerMiddleware,
-    expressMiddleware(server, { context: getContext }),
+    expressMiddleware(server, { context: async () => getContextOrThrow() }),
   );
 }
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -41,7 +41,7 @@ declare global {
 
   interface Loaders {
     articlesLoader: DataLoader<string, IArticleV2DTO | undefined>;
-    learningpathsLoader: DataLoader<string, ILearningPathV2DTO | undefined>;
+    learningpathsLoader: DataLoader<number, ILearningPathV2DTO | undefined>;
     subjectTopicsLoader: DataLoader<SubjectTopicsLoaderParams, any>;
     subjectsLoader: DataLoader<SubjectsLoaderParams, { subjects: GQLSubject[] }>;
     nodeLoader: DataLoader<NodeLoaderParams, Node>;

--- a/src/types/schema.d.ts
+++ b/src/types/schema.d.ts
@@ -1649,8 +1649,6 @@ export type GQLQuerySearchWithoutPaginationArgs = {
 
 export type GQLQuerySharedFolderArgs = {
   id: Scalars['String']['input'];
-  includeResources?: InputMaybe<Scalars['Boolean']['input']>;
-  includeSubfolders?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -11,11 +11,7 @@ import { Response } from "node-fetch";
 import { IArticleV2DTO } from "@ndla/types-backend/article-api";
 import { ILearningPathV2DTO, ILearningStepV2DTO } from "@ndla/types-backend/learningpath-api";
 import { Node, TaxonomyContext, TaxonomyCrumb } from "@ndla/types-taxonomy";
-import createFetch from "./fetch";
-import { createCache } from "../cache";
 import { apiUrl, defaultLanguage } from "../config";
-import createClient, { Client, FetchResponse, Middleware } from "openapi-fetch";
-import type { MediaType } from "openapi-typescript-helpers";
 import {
   GQLMeta,
   GQLTaxonomyEntity,
@@ -26,82 +22,15 @@ import {
   GQLMyNdlaLearningpath,
   GQLMyNdlaLearningpathStep,
 } from "../types/schema";
-import { getContext, getContextOrThrow } from "./contextMiddleware";
-import { getCorrelationId } from "./correlationIdMiddleware";
-import getLogger from "./logger";
 
-const apiBaseUrl = (() => {
-  // if (process.env.NODE_ENV === 'test') {
-  //   return 'http://some-api';
-  // }
-  return apiUrl;
-})();
-
-function apiResourceUrl(path: string): string {
+export function apiResourceUrl(path: string): string {
   if (path.startsWith("http")) {
     return path;
   }
-  return apiBaseUrl + path;
+  return apiUrl + path;
 }
 
-function buildErrorPayload(status: number, messages: string, json: any): Error {
-  return Object.assign({}, { status, json, messages }, new Error(""));
-}
-
-export const resolveOATS = async <A extends Record<string | number, any>, B, C extends MediaType>(
-  res: FetchResponse<A, B, C>,
-) => {
-  const { data, response, error } = res;
-  if (response.ok) return data;
-  const messages = getErrorMessages(error) ?? response.statusText;
-  throw buildErrorPayload(response.status, messages, error);
-};
-
-/** Resolves a response from OpenApi-TS fetch client and asserts that the response is successful */
-export const resolveJsonOATS = async <A extends Record<string | number, any>, B, C extends MediaType>(
-  res: FetchResponse<A, B, C>,
-) => {
-  const { data, response, error } = res;
-  if (response.ok && data) return data;
-  const messages = getErrorMessages(error) ?? response.statusText;
-  throw buildErrorPayload(response.status, messages, error);
-};
-
-const getErrorMessages = (err: unknown): string | undefined => {
-  if (!err || typeof err !== "object") return;
-  if ("messages" in err && typeof err.messages === "string") return err.messages;
-  if ("description" in err && typeof err.description === "string") return err.description;
-  return;
-};
-
-/** openapi-fetch middleware to add authentication headers */
-export const OATSAuthMiddleware: Middleware = {
-  async onRequest({ request, options: _options }) {
-    request.headers.set("x-correlation-id", getCorrelationId() ?? "");
-    return request;
-  },
-};
-
-export const createAuthClient = <T extends {}>() => {
-  const client = createClient<T>({
-    baseUrl: apiBaseUrl,
-    fetch: openapiFetch,
-    querySerializer: {
-      array: {
-        style: "form",
-        explode: false,
-      },
-    },
-  });
-
-  client.use(OATSAuthMiddleware);
-
-  return client;
-};
-
-const cache = createCache();
-
-function getHeadersFromContext(context: Context): {
+export function getHeadersFromContext(context: Context): {
   "Cache-Control"?: string | undefined;
   Authorization?: string | undefined;
   versionhash?: string | undefined;
@@ -118,46 +47,6 @@ function getHeadersFromContext(context: Context): {
     ...accessTokenAuth,
     ...cacheHeaders,
   };
-}
-
-async function openapiFetch(req: globalThis.Request): Promise<globalThis.Response> {
-  const startTime = performance.now();
-  const slowLogTimeout = 500;
-
-  const ctx = getContextOrThrow();
-  const headers = getHeadersFromContext(ctx);
-
-  for (const [key, value] of Object.entries(headers)) {
-    if (value !== undefined && value !== null) req.headers.set(key, value);
-  }
-
-  const response = await globalThis.fetch(req);
-
-  const elapsedTime = performance.now() - startTime;
-  if (elapsedTime > slowLogTimeout) {
-    getLogger().info(
-      `Fetching '${req.url}' took ${elapsedTime.toFixed(
-        2,
-      )}ms which is slower than slow log timeout of ${slowLogTimeout}ms`,
-    );
-  }
-
-  return response;
-}
-
-export async function fetch(path: string, context: Context, options?: RequestOptions): Promise<Response> {
-  const fetchFn = createFetch({
-    cache,
-    disableCache: !context.shouldUseCache,
-    context,
-  });
-
-  const headers = getHeadersFromContext(context);
-
-  return fetchFn(apiResourceUrl(path), context, {
-    headers,
-    ...options,
-  });
 }
 
 export async function resolveNothingFromStatus(response: Response): Promise<void> {

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -231,3 +231,14 @@ const toGQLTaxonomyCrumb = (crumb: TaxonomyCrumb, context: ContextWithLoaders): 
     name: name ?? "",
   };
 };
+
+export const getNumberId = (id: number | string): number => {
+  if (typeof id === "string") {
+    const numberId = parseInt(id);
+    if (isNaN(numberId)) {
+      throw new Error(`Invalid id: ${id}`);
+    }
+    return numberId;
+  }
+  return id;
+};

--- a/src/utils/context/contextStore.ts
+++ b/src/utils/context/contextStore.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const asyncContextStorage = new AsyncLocalStorage<ContextWithLoaders>();
+
+export function getAsyncContextStorage() {
+  return asyncContextStorage;
+}
+
+export function getContextOrThrow(): ContextWithLoaders {
+  const ctx = getContext();
+  if (ctx === undefined)
+    throw Error("Could not get context in `getContextOrThow`, did you remember to attach `contextExpressMiddleware`?");
+  return ctx;
+}
+
+export function withCustomContext<T>(
+  contextFunction: (ctx: ContextWithLoaders) => ContextWithLoaders,
+  func: () => T,
+): T {
+  const ctx = getContextOrThrow();
+  const customContext = contextFunction(ctx);
+  return asyncContextStorage.run(customContext, () => {
+    return func();
+  });
+}
+
+export function getContext(): ContextWithLoaders | undefined {
+  return asyncContextStorage.getStore();
+}

--- a/src/utils/context/contextStore.ts
+++ b/src/utils/context/contextStore.ts
@@ -17,7 +17,7 @@ export function getAsyncContextStorage() {
 export function getContextOrThrow(): ContextWithLoaders {
   const ctx = getContext();
   if (ctx === undefined)
-    throw Error("Could not get context in `getContextOrThow`, did you remember to attach `contextExpressMiddleware`?");
+    throw Error("Could not get context in `getContextOrThrow`, did you remember to attach `contextExpressMiddleware`?");
   return ctx;
 }
 

--- a/src/utils/contextMiddleware.ts
+++ b/src/utils/contextMiddleware.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { getToken } from "../auth";
+import {
+  articlesLoader,
+  subjectTopicsLoader,
+  resourceTypesLoader,
+  learningpathsLoader,
+  subjectsLoader,
+  frontpageLoader,
+  subjectpageLoader,
+  nodeLoader,
+  nodesLoader,
+  searchNodesLoader,
+} from "../loaders";
+import isString from "lodash/isString";
+import { defaultLanguage } from "../config";
+import { NextFunction, Request, Response } from "express";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+function getShouldUseCache(request: Request): boolean {
+  const cacheControl = request.headers["cache-control"]?.toLowerCase();
+  const feideAuthHeader = getFeideAuthorization(request);
+  const disableCacheHeaders = ["no-cache", "no-store"];
+
+  const cacheControlDisable = disableCacheHeaders.includes(cacheControl ?? "");
+  const feideHeaderPresent = !!feideAuthHeader;
+
+  return !cacheControlDisable && !feideHeaderPresent;
+}
+
+const getTaxonomyUrl = (request: Request): string => {
+  const taxonomyUrl = request.headers["use-taxonomy2"];
+  return taxonomyUrl === "true" ? "taxonomy2" : "taxonomy";
+};
+
+function getVersionHash(request: Request): string | undefined {
+  return getHeaderString(request, "versionhash");
+}
+
+function getAcceptLanguage(request: Request): string {
+  const language = request.headers["accept-language"];
+
+  if (isString(language)) {
+    return language.split("-")[0] ?? defaultLanguage;
+  }
+  return defaultLanguage;
+}
+
+function getHeaderString(request: Request, name: string): string | undefined {
+  const header = request.headers[name];
+
+  if (isString(header)) {
+    return header;
+  }
+  return undefined;
+}
+
+function getFeideAuthorization(request: Request): string | undefined {
+  return getHeaderString(request, "feideauthorization");
+}
+
+const asyncContextStorage = new AsyncLocalStorage<ContextWithLoaders>();
+
+export function contextExpressMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const token = getToken(req);
+  const feideAuthorization = getFeideAuthorization(req);
+  const versionHash = getVersionHash(req);
+
+  const language = getAcceptLanguage(req);
+  const shouldUseCache = getShouldUseCache(req);
+  const taxonomyUrl = getTaxonomyUrl(req);
+  const defaultContext = {
+    language,
+    token,
+    feideAuthorization,
+    versionHash,
+    shouldUseCache,
+    taxonomyUrl,
+    req,
+    res,
+  };
+
+  const contextObject = {
+    ...defaultContext,
+    loaders: {
+      articlesLoader: articlesLoader(defaultContext),
+      subjectTopicsLoader: subjectTopicsLoader(defaultContext),
+      learningpathsLoader: learningpathsLoader(defaultContext),
+      resourceTypesLoader: resourceTypesLoader(defaultContext),
+      nodeLoader: nodeLoader(defaultContext),
+      nodesLoader: nodesLoader(defaultContext),
+      subjectsLoader: subjectsLoader(defaultContext),
+      frontpageLoader: frontpageLoader(defaultContext),
+      subjectpageLoader: subjectpageLoader(defaultContext),
+      searchNodesLoader: searchNodesLoader(defaultContext),
+    },
+  };
+
+  asyncContextStorage.run(contextObject, () => {
+    next();
+  });
+}
+
+export function getContextOrThrow(): ContextWithLoaders {
+  const ctx = getContext();
+  if (ctx === undefined)
+    throw Error("Could not get context in `getContextOrThow`, did you remember to attach `contextExpressMiddleware`?");
+  return ctx;
+}
+
+export function getContext(): ContextWithLoaders | undefined {
+  return asyncContextStorage.getStore();
+}

--- a/src/utils/openapi-fetch/cacheMiddleware.ts
+++ b/src/utils/openapi-fetch/cacheMiddleware.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Middleware } from "openapi-fetch";
+import { getContextOrThrow } from "../context/contextStore";
+import { cacheTime, getCache, getCacheKey, setHeaderIfShouldNotCache } from "../../cache";
+
+export function cachedResponse(data: string | undefined): globalThis.Response | null {
+  if (!data) return null;
+
+  const { body, headers } = JSON.parse(data);
+  return new globalThis.Response(body, {
+    headers,
+    status: 200,
+  });
+}
+
+export const OATSCacheMiddleware: Middleware = {
+  async onRequest({ request }) {
+    const ctx = getContextOrThrow();
+    const cacheControl = request.headers.get("Cache-Control");
+
+    const isCachable =
+      (request.method === undefined || request.method === "GET") &&
+      cacheControl !== "no-store" &&
+      cacheControl !== "reload";
+
+    if (!isCachable) return request;
+
+    const cacheKey = getCacheKey(request.url, ctx);
+    const data = await getCache().get(cacheKey);
+    const cached = cachedResponse(data);
+    if (cached) return cached;
+    return request;
+  },
+  async onResponse({ request, response }) {
+    const ctx = getContextOrThrow();
+    const shouldCache = setHeaderIfShouldNotCache(response, ctx);
+    const body = await response.text();
+    if (response.status === 200) {
+      if (shouldCache) {
+        const cacheKey = getCacheKey(request.url, ctx);
+        const headers: Record<string, unknown> = {};
+        response.headers.forEach((value, key) => (headers[key] = value));
+        await getCache().set(
+          cacheKey,
+          JSON.stringify({
+            body,
+            headers,
+          }),
+          cacheTime,
+        );
+      }
+    }
+    const responseOpts = {
+      ...response,
+      headers: response.headers,
+      status: response.status,
+    };
+
+    return new globalThis.Response(body, responseOpts);
+  },
+};

--- a/src/utils/openapi-fetch/cacheMiddleware.ts
+++ b/src/utils/openapi-fetch/cacheMiddleware.ts
@@ -24,12 +24,12 @@ export const OATSCacheMiddleware: Middleware = {
   async onRequest({ request }) {
     const cacheControl = request.headers.get("Cache-Control");
 
-    const isCachable =
+    const isCacheable =
       (request.method === undefined || request.method === "GET") &&
       cacheControl !== "no-store" &&
       cacheControl !== "reload";
 
-    if (!isCachable) return request;
+    if (!isCacheable) return request;
 
     const ctx = getContextOrThrow();
     const cacheKey = getCacheKey(request.url, ctx);

--- a/src/utils/openapi-fetch/cacheMiddleware.ts
+++ b/src/utils/openapi-fetch/cacheMiddleware.ts
@@ -22,7 +22,6 @@ export function cachedResponse(data: string | undefined): globalThis.Response | 
 
 export const OATSCacheMiddleware: Middleware = {
   async onRequest({ request }) {
-    const ctx = getContextOrThrow();
     const cacheControl = request.headers.get("Cache-Control");
 
     const isCachable =
@@ -32,6 +31,7 @@ export const OATSCacheMiddleware: Middleware = {
 
     if (!isCachable) return request;
 
+    const ctx = getContextOrThrow();
     const cacheKey = getCacheKey(request.url, ctx);
     const data = await getCache().get(cacheKey);
     const cached = cachedResponse(data);

--- a/src/utils/openapi-fetch/internalUrlMiddleware.ts
+++ b/src/utils/openapi-fetch/internalUrlMiddleware.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import { Middleware } from "openapi-fetch";
+import { apiResourceUrl } from "../apiHelpers";
+import { environmentApiHost } from "../../config";
+
+/** This middleware replaces ndla api urls with internal api-gateway if applicable */
+export const OATSInternalUrlMiddleware: Middleware = {
+  async onRequest({ request }) {
+    const url = new URL(request.url);
+    const withoutHost = url.toString().replace(url.origin, "");
+    if (url.hostname === environmentApiHost) {
+      const newUrl = apiResourceUrl(withoutHost);
+      return new globalThis.Request(newUrl, request);
+    }
+    return request;
+  },
+};

--- a/src/utils/openapi-fetch/utils.ts
+++ b/src/utils/openapi-fetch/utils.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2025-present, NDLA.
+ *
+ * This source code is licensed under the GPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import createClient, { FetchResponse } from "openapi-fetch";
+import type { MediaType } from "openapi-typescript-helpers";
+import { OATSCacheMiddleware } from "./cacheMiddleware";
+import { OATSInternalUrlMiddleware } from "./internalUrlMiddleware";
+import { getHeadersFromContext } from "../apiHelpers";
+import getLogger from "../logger";
+import { GraphQLError } from "graphql";
+import { apiUrl } from "../../config";
+import { getContextOrThrow } from "../context/contextStore";
+
+export const resolveOATS = async <A extends Record<string | number, any>, B, C extends MediaType>(
+  res: FetchResponse<A, B, C>,
+) => {
+  const { data, response, error } = res;
+  if (response.ok) return data;
+
+  const message = `Api call to ${response.url} failed with status ${response.status} ${response.statusText}`;
+  throw new GraphQLError(message, { extensions: { status: response.status, json: error ?? data } });
+};
+
+/** Resolves a response from OpenApi-TS fetch client and asserts that the response is successful */
+export const resolveJsonOATS = async <A extends Record<string | number, any>, B, C extends MediaType>(
+  res: FetchResponse<A, B, C>,
+) => {
+  const { data, response, error } = res;
+  if (response.ok && data) return data;
+  const message = `Api call to ${response.url} failed with status ${response.status} ${response.statusText}`;
+  throw new GraphQLError(message, { extensions: { status: response.status, json: error ?? data } });
+};
+
+export interface ClientCreateOptions {
+  disableCache?: boolean;
+}
+
+export function createAuthClient<T extends {}>(options?: ClientCreateOptions) {
+  const client = createClient<T>({
+    baseUrl: apiUrl,
+    fetch: fetchFunction,
+    querySerializer: {
+      array: {
+        style: "form",
+        explode: false,
+      },
+    },
+  });
+
+  if (!options?.disableCache) client.use(OATSCacheMiddleware);
+  client.use(OATSInternalUrlMiddleware);
+
+  return client;
+}
+
+async function fetchFunction(req: globalThis.Request): Promise<globalThis.Response> {
+  const startTime = performance.now();
+  const slowLogTimeout = 500;
+
+  const ctx = getContextOrThrow();
+  const headers = getHeadersFromContext(ctx);
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (value !== undefined && value !== null) req.headers.set(key, value);
+  }
+
+  const response = await globalThis.fetch(req);
+
+  const elapsedTime = performance.now() - startTime;
+  if (elapsedTime > slowLogTimeout) {
+    getLogger().info(
+      `Fetching '${req.url}' took ${elapsedTime.toFixed(
+        2,
+      )}ms which is slower than slow log timeout of ${slowLogTimeout}ms`,
+    );
+  }
+
+  return response;
+}

--- a/src/utils/visualelementHelpers.ts
+++ b/src/utils/visualelementHelpers.ts
@@ -12,7 +12,7 @@ import { convertToSimpleImage, fetchImage } from "../api/imageApi";
 import { fetchOembed } from "../api/oembedApi";
 import { fetchVideo, fetchVideoSources } from "../api/videoApi";
 import { getBrightcoveCopyright } from "./brightcoveUtils";
-import { GQLCopyright, GQLH5pElement, GQLVisualElement, GQLVisualElementOembed } from "../types/schema";
+import { GQLCopyright, GQLVisualElement } from "../types/schema";
 
 export async function parseVisualElement(
   visualElementEmbed: string,
@@ -93,7 +93,7 @@ const parseH5PFromEmbed = async (embedData: VisualElementH5P, context: Context):
   const h5pId = pathArr[pathArr.length - 1];
   const [license, visualElementOembed, h5pInfo] = await Promise.all([
     fetchH5pLicenseInformation(h5pId, context),
-    fetchOembed<GQLH5pElement>(embedData.url, context),
+    fetchOembed(embedData.url, context),
     fetchH5pInfo(h5pId, context),
   ]);
 
@@ -160,7 +160,7 @@ const parseOembedFromEmbed = async (
   embedData: VisualElementOembed,
   context: Context,
 ): Promise<GQLVisualElement | null> => {
-  const visualElementOembed = await fetchOembed<GQLVisualElementOembed>(embedData.url, context);
+  const visualElementOembed = await fetchOembed(embedData.url, context);
   if (!visualElementOembed) return null;
   return {
     url: embedData.url,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7726,6 +7726,7 @@ __metadata:
     nock: "npm:^13.2.9"
     node-fetch: "npm:2.6.7"
     open-graph-scraper: "npm:^6.8.3"
+    openapi-fetch: "npm:^0.13.5"
     prettier: "npm:^3.1.0"
     prismjs: "npm:^1.29.0"
     prom-client: "npm:^15.1.3"
@@ -8017,6 +8018,22 @@ __metadata:
     iconv-lite: "npm:^0.6.3"
     undici: "npm:^6.21.0"
   checksum: 10c0/85f65f250b13b1c51ac2d88cf7fe0cc5691cc63d002ec0cf6462371736b4d2a59d386453a61bc11d7bdb568afca5dd36c43641e1e296afe924109d265ac16588
+  languageName: node
+  linkType: hard
+
+"openapi-fetch@npm:^0.13.5":
+  version: 0.13.5
+  resolution: "openapi-fetch@npm:0.13.5"
+  dependencies:
+    openapi-typescript-helpers: "npm:^0.0.15"
+  checksum: 10c0/57736d9d4310d7bc7fa5e4e37e80d28893a7fefee88ee6e0327600de893e0638479445bf0c9f5bd7b1a2429f409425d3945d6e942b23b37b8081630ac52244fb
+  languageName: node
+  linkType: hard
+
+"openapi-typescript-helpers@npm:^0.0.15":
+  version: 0.0.15
+  resolution: "openapi-typescript-helpers@npm:0.0.15"
+  checksum: 10c0/5eb68d487b787e3e31266470b1a310726549dd45a1079655ab18066ab291b0b3c343fdf629991013706a2329b86964f8798d56ef0272b94b931fe6c19abd7a88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Flytter rundt på en del kode for å fikse noen sirkulære avhengigheter
- Implementere `asyncLocalStorage` for å håndtere `context`
- Implementere `cacheMiddleware` for `openapi-fetch`
- Skrive om alle `backend` api filene til å bruke `openapi-fetch` klienter.