### PR TITLE
Send bigger pageSize to node-search

### DIFF
--- a/src/api/taxonomyApi.ts
+++ b/src/api/taxonomyApi.ts
@@ -64,6 +64,8 @@ export async function searchNodes(params: { contentUris: string[] }, context: Co
     isVisible: true,
     includeContexts: true,
     filterProgrammes: true,
+    page: 1,
+    pageSize: 100,
   });
   const response = await taxonomyFetch(`/${context.taxonomyUrl}/v1/nodes/search?${query}`, context);
   return await resolveJson(response);


### PR DESCRIPTION
Oppdaga at lenke til læringssti i [denne mappa](https://test.ndla.no/nb/minndla/folders/9b8bc6eb-f7ee-43ff-9611-d5d4494563ce) ikkje hadde path. Det var fordi søket mot taksonomi hadde 14 treff men berre 10 resultat på grunn av sidestørrelse på 10, så derfor kom ikkje søketreffet på læringsstien med. 
Alle søk med emner kan potensielt gi mange treff dersom dei er brukt mange plasser.